### PR TITLE
Fix milkdown entry on mobile

### DIFF
--- a/src/app/components/Guestbook.tsx
+++ b/src/app/components/Guestbook.tsx
@@ -212,23 +212,14 @@ export default function Guestbook() {
             <label className="block text-sm font-medium text-foreground mb-2">
               Your Message
             </label>
-            <div className="relative">
+            <div className="relative gb-editor">
               <MilkdownEditor
                 value={formData.message}
                 onChange={(value) => setFormData(prev => ({ ...prev, message: value }))}
-                className="min-h-[200px]"
+                className="min-h-[160px] md:min-h-[200px]"
               />
             </div>
-            <div className="flex justify-between items-center mt-2">
-              <p className="text-xs text-muted-foreground">
-                {formData.message.length}/5000 characters • Use / for formatting commands
-              </p>
-              <div className="flex space-x-2 text-xs text-muted-foreground">
-                <span>Type / for commands</span>
-                <span>Ctrl+B for bold</span>
-                <span>Ctrl+I for italic</span>
-              </div>
-            </div>
+            {/* Helper text removed per request */}
           </div>
 
           {/* Social Links */}

--- a/src/app/components/MilkdownEditor.tsx
+++ b/src/app/components/MilkdownEditor.tsx
@@ -14,6 +14,7 @@ interface MilkdownEditorProps {
 export default function MilkdownEditor({ value, onChange, className }: MilkdownEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null)
   const crepeRef = useRef<Crepe | null>(null)
+  const creatingRef = useRef(false)
   const onChangeRef = useRef(onChange)
 
   // Keep onChange ref up to date
@@ -22,14 +23,15 @@ export default function MilkdownEditor({ value, onChange, className }: MilkdownE
   }, [onChange])
 
   useEffect(() => {
-    if (!editorRef.current || crepeRef.current) return
+    if (!editorRef.current || crepeRef.current || creatingRef.current) return
 
-    let isCreating = false
+    creatingRef.current = true
     const initialValue = value
 
     const initEditor = async () => {
-      if (isCreating) return
-      isCreating = true
+      if (!editorRef.current) return
+      // Ensure the mount root is clean to avoid duplicate editors in StrictMode/dev
+      editorRef.current.innerHTML = ''
 
       try {
         const crepe = new Crepe({
@@ -85,9 +87,10 @@ export default function MilkdownEditor({ value, onChange, className }: MilkdownE
         await crepe.create()
         console.log('✅ Crepe editor created!')
         crepeRef.current = crepe
+        creatingRef.current = false
       } catch (err) {
         console.error('❌ Failed to create Crepe:', err)
-        isCreating = false
+        creatingRef.current = false
       }
     }
 
@@ -102,6 +105,7 @@ export default function MilkdownEditor({ value, onChange, className }: MilkdownE
         }
         crepeRef.current = null
       }
+      creatingRef.current = false
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // Only initialize once on mount

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,18 @@
     display: none !important;
   }
 
+  /* Hide add/plus block button and block handle toolbars entirely */
+  .crepe-editor [data-add-button],
+  .crepe-editor .add-button,
+  .crepe-editor [class*='add-button'],
+  .crepe-editor [class*='block-handle'],
+  .crepe-editor .block-handle,
+  .crepe-editor [class*='plus'],
+  .crepe-editor [aria-label='Add'],
+  .crepe-editor [title*='Add'] {
+    display: none !important;
+  }
+
   /* Disable element dragging which ProseMirror may enable via draggable=true */
   .crepe-editor .ProseMirror [draggable="true"] {
     -webkit-user-drag: none !important;
@@ -23,9 +35,7 @@
 }
 
 /* Ensure only one .milkdown mount inside our guestbook editor wrapper */
-.gb-editor .milkdown ~ .milkdown {
-  display: none !important;
-}
+.gb-editor .milkdown ~ .milkdown { display: none !important; }
 
 
 :root {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,33 @@
 @import "tailwindcss";
 
+/* Guestbook / Milkdown mobile usability tweaks */
+@media (max-width: 1279px) {
+  /* Reduce padding inside Milkdown editor content area for smaller screens */
+  .crepe-editor .milkdown,
+  .crepe-editor .ProseMirror {
+    padding: 8px !important;
+  }
+
+  /* Hide any drag handles if present and prevent drag interactions */
+  .crepe-editor .drag-handle,
+  .crepe-editor [data-drag-handle],
+  .crepe-editor [class*='drag-handle'] {
+    display: none !important;
+  }
+
+  /* Disable element dragging which ProseMirror may enable via draggable=true */
+  .crepe-editor .ProseMirror [draggable="true"] {
+    -webkit-user-drag: none !important;
+    user-drag: none !important;
+  }
+}
+
+/* Ensure only one .milkdown mount inside our guestbook editor wrapper */
+.gb-editor .milkdown ~ .milkdown {
+  display: none !important;
+}
+
+
 :root {
   /* Light theme */
   --background: #ffffff;


### PR DESCRIPTION
remove drag and drop functionality below 1280px, and reduced padding to make more room for content entry. Fixed a strange error where the editor was showing up twice on all viewport sizes. 