### PR TITLE
feat(about): reorder sections and update 'About this site'

### DIFF
--- a/src/app/components/AboutContent.tsx
+++ b/src/app/components/AboutContent.tsx
@@ -3,7 +3,25 @@ import React from 'react'
 const AboutContent: React.FC = () => {
   return (
     <div className="space-y-8">
-      {/* About David Card */}
+      {/* About this site Card (now first) */}
+      <section className="bg-background border border-neutral-100/6 p-6">
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold text-accent font-[family-name:var(--font-geist-mono)] mb-2">About this site</h2>
+        </div>
+        <div className="space-y-4 text-foreground/80 leading-relaxed">
+          <p>
+            Building and maintaining a portfolio site has always been at the absolute bottom of my list of things I&apos;m excited to spend time on. But... there’s this new thing — I dunno if you’ve heard of it — it’s called AI, and it’s kind of revolutionizing software development. 😏
+          </p>
+          <p>
+            So this site is a bit of an experiment. It&apos;s the product of AI-assisted software development (distinctly different from “vibe coding”). I&apos;ve open-sourced the whole thing too, for anyone who wants a nifty little portfolio site to tinker with. Go ahead, take a peek under the hood. Heck, open an issue and tell me what I did wrong — or better yet, just make a PR and fix it!
+          </p>
+          <p>
+            <a href="https://github.com/levinmedia/portfolio" target="_blank" rel="noopener noreferrer" className="underline text-accent hover:text-accent/80">https://github.com/levinmedia/portfolio</a>
+          </p>
+        </div>
+      </section>
+
+      {/* About David Card (now second) */}
       <section className="bg-background border border-neutral-100/6 p-6">
         <div className="mb-6">
           <h2 className="text-xl font-semibold text-accent font-[family-name:var(--font-geist-mono)] mb-2">About David</h2>
@@ -24,25 +42,6 @@ const AboutContent: React.FC = () => {
           
           <p className="text-sm text-foreground/60 italic">
             And yes, this was absolutely written by AI, and edited lightly for style, context, and clarity.
-          </p>
-        </div>
-      </section>
-
-      {/* About this site Card */}
-      <section className="bg-background border border-neutral-100/6 p-6">
-        <div className="mb-6">
-          <h2 className="text-xl font-semibold text-accent font-[family-name:var(--font-geist-mono)] mb-2">About this site</h2>
-        </div>
-        <div className="space-y-4 text-foreground/80 leading-relaxed">
-          <p>
-            Building and maintaining a portfolio site has always been at the absolute bottom of my list of things I&apos;m excited to spend time on. But... there’s this new thing — I dunno if you’ve heard of it — it’s called AI, and it’s kind of revolutionizing software development. 😏
-          </p>
-          <p>
-            So this site is a bit of an experiment. It&apos;s the product of AI-assisted software development (distinctly different from “vibe coding”). I&apos;ve open-sourced the whole thing too, for anyone who wants a nifty little portfolio site to tinker with. Go ahead, take a peek under the hood. Heck, open an issue and tell me what I did wrong — or better yet, just make a PR and fix it!
-          </p>
-          <p>
-            Lastly, all of the components are available for preview at 
-            <a href="https://storybook.levinmedia.vercel.app" target="_blank" rel="noopener noreferrer" className="underline text-accent hover:text-accent/80"> storybook.levinmedia.vercel.app</a>.
           </p>
         </div>
       </section>


### PR DESCRIPTION
- About this site' now appears first
- Updated copy and added GitHub repo link 
- 'About David' moved to second section