### PR TITLE
Adjust mobile drawer height to reach viewport top

### DIFF
--- a/src/app/components/Drawer.tsx
+++ b/src/app/components/Drawer.tsx
@@ -50,9 +50,9 @@ const Drawer: React.FC<DrawerProps> = ({
   return (
     <>
       {/* Drawer */}
-      <div 
+      <div
         className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 bg-background border border-blue-200/15 rounded-none transition-transform duration-300 ease-out w-full max-w-sm sm:max-w-[640px] md:max-w-[768px] lg:max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1536px] drawer-container ${
-          isOpen ? 'translate-y-[-64px]' : 'translate-y-full'
+          isOpen ? 'translate-y-0' : 'translate-y-full'
         }`}
         style={{
           overflowY: 'auto',

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -287,22 +287,23 @@
 
 /* Drawer height handling */
 .drawer-container {
-  height: calc(100vh - 64px);
-  max-height: 80vh; /* Mobile fallback */
+  height: 100vh;
+  max-height: 100vh;
 }
 
 @media (min-width: 768px) {
   .drawer-container {
     height: calc(100vh - 64px);
-    max-height: calc(100vh - 64px); /* Full height on desktop */
+    max-height: calc(100vh - 64px); /* Align with global header on desktop */
   }
 }
 
 @supports (height: 100dvh) {
   .drawer-container {
-    height: calc(100dvh - 64px);
+    height: 100dvh;
+    max-height: 100dvh;
   }
-  
+
   @media (min-width: 768px) {
     .drawer-container {
       height: calc(100vh - 64px); /* Use regular vh on desktop */


### PR DESCRIPTION
## Summary
- let the drawer occupy the full viewport height on mobile so its header is flush with the top edge
- retain the desktop offset while using modern viewport units when available
- remove the negative translate offset now that the drawer can open to the top

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fecf600c5883299f68533193a4643a