### PR TITLE
fix: eliminate loading flash on initial page load

### DIFF
--- a/src/app/components/Howdy.tsx
+++ b/src/app/components/Howdy.tsx
@@ -64,7 +64,7 @@ export default function Howdy({ onSelectedWorksClick, onSiteSettingsClick }: How
     return (
       <div className="row-start-2 col-span-6 flex flex-col lg:flex-row items-center lg:items-start" style={{ gap: 'var(--grid-major)' }}>
         <div className="w-full text-center text-foreground/60">
-          Loading...
+          {/* Loading skeleton - invisible but maintains layout */}
         </div>
       </div>
     )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -320,6 +320,17 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans), sans-serif;
   transition: background-color 0.3s ease, color 0.3s ease;
+  /* Prevent flash of unstyled content */
+  opacity: 1;
+}
+
+/* Hide body until fonts and styles are ready */
+body:not(.fonts-loaded) {
+  opacity: 0;
+}
+
+html:not(.hydrated) body {
+  visibility: hidden;
 }
 
 /* Responsive grid sizing */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import AnalyticsTracker from "./components/AnalyticsTracker";
 import { Suspense } from "react";
 import { Analytics } from "@vercel/analytics/next";
+import Script from "next/script";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -29,15 +30,25 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="hydrated">
       <body
-        className={`${inter.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${geistMono.variable} antialiased fonts-loaded`}
       >
         <Suspense fallback={null}>
           <AnalyticsTracker />
         </Suspense>
         {children}
         <Analytics />
+        <Script
+          id="prevent-fouc"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              document.documentElement.classList.add('hydrated');
+              document.body.classList.add('fonts-loaded');
+            `,
+          }}
+        />
       </body>
     </html>
   );

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+export default function Loading() {
+  // Return null to prevent any loading UI from showing
+  return null;
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -211,7 +211,7 @@ function HomeContent() {
 
 export default function Home() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={null}>
       <HomeContent />
     </Suspense>
   );


### PR DESCRIPTION
- Add loading.tsx that returns null to prevent Next.js default loading UI
- Add CSS rules to hide body until fonts/styles are ready
- Update layout to add hydrated and fonts-loaded classes
- Change Suspense fallback from 'Loading...' to null
- Remove visible 'Loading...' text from Howdy component