### PR TITLE
Adjust drawer background to scroll and tile

### DIFF
--- a/src/app/components/Drawer.tsx
+++ b/src/app/components/Drawer.tsx
@@ -63,15 +63,17 @@ const Drawer: React.FC<DrawerProps> = ({
             linear-gradient(90deg, rgba(115, 115, 115, 0.03) 1px, transparent 1px),
             linear-gradient(rgba(115, 115, 115, 0.06) 1px, transparent 1px),
             linear-gradient(90deg, rgba(115, 115, 115, 0.06) 1px, transparent 1px),
-            repeating-linear-gradient(90deg, 
-              rgba(0, 100, 255, 0.015) 0, 
-              rgba(0, 100, 255, 0.015) calc((100% - 5 * var(--grid-major)) / 6), 
-              transparent calc((100% - 5 * var(--grid-major)) / 6), 
+            repeating-linear-gradient(90deg,
+              rgba(0, 100, 255, 0.015) 0,
+              rgba(0, 100, 255, 0.015) calc((100% - 5 * var(--grid-major)) / 6),
+              transparent calc((100% - 5 * var(--grid-major)) / 6),
               transparent calc((100% - 5 * var(--grid-major)) / 6 + var(--grid-major))
             )
           `,
           backgroundSize: 'var(--grid-size) var(--grid-size), var(--grid-size) var(--grid-size), var(--grid-major) var(--grid-major), var(--grid-major) var(--grid-major), 100% 100%',
-          backgroundPosition: 'var(--grid-major) var(--grid-major), var(--grid-major) var(--grid-major), var(--grid-major) var(--grid-major), var(--grid-major) var(--grid-major), 0 0'
+          backgroundPosition: 'var(--grid-major) var(--grid-major), var(--grid-major) var(--grid-major), var(--grid-major) var(--grid-major), var(--grid-major) var(--grid-major), 0 0',
+          backgroundAttachment: 'local, local, local, local, local',
+          backgroundRepeat: 'repeat, repeat, repeat, repeat, repeat'
         }}
       >
         {/* Header */}


### PR DESCRIPTION
## Summary
- ensure the drawer background uses local attachment so the grid pattern scrolls with its content
- explicitly repeat the background layers so the pattern tiles instead of appearing fixed

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691023d1ff90832992442100bd6cc91b)