### PR TITLE
Center OG image background for field notes

### DIFF
--- a/src/app/field-notes/[slug]/opengraph-image.tsx
+++ b/src/app/field-notes/[slug]/opengraph-image.tsx
@@ -22,13 +22,6 @@ export default async function Image({
   }
 
   const backgroundImage = note.feature_image_url
-  // Map admin vertical alignment to explicit Y percentages; X stays centered.
-  const verticalAlign = (() => {
-    const align = (note.og_vertical_align || 'center').toLowerCase()
-    if (align === 'top') return '20%'    // bias upward
-    if (align === 'bottom') return '80%' // bias downward
-    return '50%' // center
-  })()
   return new ImageResponse(
     (
       <div
@@ -37,9 +30,9 @@ export default async function Image({
           height: '100%',
           backgroundImage: `url(${backgroundImage})`,
           backgroundSize: 'cover',
-          backgroundPosition: '50% 50%', // lock X to center
+          backgroundPosition: '50% 50%', // lock to center to avoid tiling/splitting
           backgroundPositionX: '50%',
-          backgroundPositionY: verticalAlign, // only Y moves based on setting
+          backgroundPositionY: '50%', // temporarily ignore vertical alignment setting
           backgroundRepeat: 'no-repeat'
         }}
       />


### PR DESCRIPTION
## Summary
- remove vertical alignment overrides for field note OG images
- lock background positioning to center to prevent tiling/splitting artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d8869c6708329ab26549ab9c5a3ea)