### PR TITLE
Use cover-fitted image for OG response

### DIFF
--- a/src/app/field-notes/[slug]/opengraph-image.tsx
+++ b/src/app/field-notes/[slug]/opengraph-image.tsx
@@ -21,21 +21,29 @@ export default async function Image({
     return new Response('Not found', { status: 404 })
   }
 
-  const backgroundImage = note.feature_image_url
   return new ImageResponse(
     (
       <div
         style={{
           width: '100%',
           height: '100%',
-          backgroundImage: `url(${backgroundImage})`,
-          backgroundSize: 'cover',
-          backgroundPosition: '50% 50%', // lock to center to avoid tiling/splitting
-          backgroundPositionX: '50%',
-          backgroundPositionY: '50%', // temporarily ignore vertical alignment setting
-          backgroundRepeat: 'no-repeat'
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#0f172a',
         }}
-      />
+      >
+        <img
+          src={note.feature_image_url}
+          alt={note.title}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            objectPosition: 'center center',
+          }}
+        />
+      </div>
     ),
     {
       width: size.width,


### PR DESCRIPTION
## Summary
- render the field note OG image with an img tag using object-fit cover to avoid tiling
- keep the OG response centered and full-bleed with a neutral fallback background

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d9101da8c8329bddeccdf9f6f9f13)