### PR TITLE
Align home hero with nav height

### DIFF
--- a/src/app/components/Howdy.tsx
+++ b/src/app/components/Howdy.tsx
@@ -5,6 +5,7 @@ import Tooltip from './Tooltip'
 import { CommandLineIcon, CogIcon } from '@heroicons/react/24/outline'
 import Button from './Button'
 import ButtonTooltip from './ButtonTooltip'
+import { NAV_HEIGHT } from './layoutConstants'
 
 interface HowdyData {
   image_src: string
@@ -49,7 +50,13 @@ export default function Howdy({ data = DEFAULT_DATA, onSelectedWorksClick, onSit
   }
 
   return (
-    <div className="row-start-2 col-span-6 flex flex-col items-center justify-center" style={{ gap: 'calc(var(--grid-major) * 2)' }}>
+    <div
+      className="row-start-2 col-span-6 flex flex-col items-center justify-center"
+      style={{
+        gap: 'calc(var(--grid-major) * 2)',
+        minHeight: `calc(100svh - ${NAV_HEIGHT}px)`
+      }}
+    >
       
       {/* Horizontal Split Layout */}
       <div className="w-full sm:w-fit border border-blue-200/15 rounded-none backdrop-blur-sm bg-background p-8 sm:p-12 lg:p-16 xl:p-20">

--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -7,6 +7,7 @@ import Drawer from './Drawer'
 import ViewportDebug from './ViewportDebug'
 import LevinMediaLogo from './LevinMediaLogo'
 import Tooltip from './Tooltip'
+import { NAV_HEIGHT } from './layoutConstants'
 import { 
   Bars3Icon,
   CommandLineIcon, 
@@ -153,10 +154,10 @@ export default function Navigation() {
         fullWidth={true}
       >
         <>
-          <nav className="flex items-center justify-between bg-background border border-blue-200/15 rounded-none w-full" style={{ 
-            gap: 'var(--grid-major)', 
-            padding: 'var(--grid-major)', 
-            height: '64px'
+          <nav className="flex items-center justify-between bg-background border border-blue-200/15 rounded-none w-full" style={{
+            gap: 'var(--grid-major)',
+            padding: 'var(--grid-major)',
+            height: `${NAV_HEIGHT}px`
           }}>
             {/* Logo - always visible */}
             <LevinMediaLogo size={32} onClick={handleLogoClick} />

--- a/src/app/components/layoutConstants.ts
+++ b/src/app/components/layoutConstants.ts
@@ -1,0 +1,1 @@
+export const NAV_HEIGHT = 64

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import StatsContent from "./components/StatsContent";
 import Guestbook from "./components/Guestbook";
 import Howdy from "./components/Howdy";
 import Navigation from "./components/Navigation";
+import { NAV_HEIGHT } from "./components/layoutConstants";
 import { ParticleBackground } from "./components/ParticleBackground";
 import { usePageTitle } from "./hooks/usePageTitle";
 
@@ -127,9 +128,10 @@ function HomeContent() {
   };
 
   return (
-    <div className="relative grid grid-cols-6 items-center min-h-screen font-[family-name:var(--font-geist-sans)] border border-blue-200/20 mx-auto px-4 sm:px-0 max-w-sm sm:max-w-[640px] md:max-w-[768px] lg:max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1536px]" style={{ 
+    <div className="relative grid grid-cols-6 items-center min-h-svh overflow-hidden font-[family-name:var(--font-geist-sans)] border border-blue-200/20 mx-auto px-4 sm:px-0 max-w-sm sm:max-w-[640px] md:max-w-[768px] lg:max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1536px]" style={{
       gridTemplateRows: 'var(--grid-major) 1fr 0',
       gap: 'var(--grid-major)',
+      paddingBottom: `${NAV_HEIGHT}px`
     }}>
       {/* Particle Background Layer - constrained to wrapper */}
       <div className="absolute inset-0 z-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- ensure home layout uses shared navigation height constant and fills the viewport
- center the Howdy hero within the viewport minus navigation height on mobile
- expose navigation height constant for consistent styling

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e48366ffc8329a9efe132997d3299)