### PR TITLE
Fix mobile /sign-in overflow by fixing background and centering content

### DIFF
--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -82,15 +82,15 @@ export default function SignInPage() {
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden font-[family-name:var(--font-geist-sans)] bg-background text-foreground">
+    <div className="relative h-dvh min-h-screen overflow-hidden font-[family-name:var(--font-geist-sans)] bg-background text-foreground">
       {/* Particle background - same as home page */}
-      <div className="absolute inset-0 z-0 overflow-hidden">
+      <div className="fixed inset-0 z-0 overflow-hidden">
         <ParticleBackground />
       </div>
 
       {/* Grid pattern overlay */}
       <div
-        className="absolute inset-0 z-[1] pointer-events-none"
+        className="fixed inset-0 z-[1] pointer-events-none"
         style={{
           backgroundImage: `
             linear-gradient(rgba(115, 115, 115, 0.03) 1px, transparent 1px),
@@ -110,7 +110,7 @@ export default function SignInPage() {
       />
 
       {/* Content */}
-      <div className="relative z-10 flex items-center justify-center min-h-screen py-12 px-4 sm:px-6 lg:px-8">
+      <div className="relative z-10 flex h-full items-center justify-center px-4 py-4 sm:px-6 sm:py-12 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="mt-6 flex items-center justify-center gap-3">
           <div className="sm:hidden">


### PR DESCRIPTION
### Motivation

- Mobile users experienced vertical scrolling on `/sign-in` because the background and layout were not constrained to the viewport height.  
- The background layers moved with the content instead of staying fixed, causing a distracting UX when the keyboard or scrolling occurred.  
- The sign-in card needed to be vertically centered in a mobile-safe way so it appears to float in the middle of the screen.

### Description

- Constrain the page root to the viewport by adding `h-dvh` alongside `min-h-screen` on the `/sign-in` container in `src/app/sign-in/page.tsx`.  
- Make the particle background and grid overlay `fixed` instead of `absolute` so the background remains stationary during interaction.  
- Change the foreground wrapper to use full-height flex centering with `h-full items-center justify-center` and adjust padding to center the sign-in card vertically on mobile.  
- Updated the layout-related Tailwind class names only; no business logic was changed.

### Testing

- Ran `npm run lint`, which completed successfully (existing unrelated warnings remain).  
- Started the dev server with `npm run dev -- --port 3000` and rendered `/sign-in` successfully under a mobile viewport using a Playwright script, which produced a screenshot confirming the visual fix.  
- The dev run logged network/font fetch warnings and a missing Supabase env error for an unrelated API route, but those did not prevent rendering of the `/sign-in` page (issues are environmental and unrelated to the layout change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d5aaac188329bc52acfae2db3b3e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind/CSS-only layout tweaks confined to the sign-in page; no auth or data-handling logic changes.
> 
> **Overview**
> Fixes `/sign-in` mobile overflow and unintended scrolling by constraining the page container to the viewport (`h-dvh`) while keeping `min-h-screen`.
> 
> Pins the particle background and grid overlay by switching them from `absolute` to `fixed`, and updates the content wrapper to use full-height flex centering (`h-full items-center justify-center`) with adjusted padding for better vertical centering on small screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10f725d74663910f2157f5290019dd0cea54d945. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->