### PR TITLE
Whitelist and validate OG image URLs for field-notes Open Graph image

### DIFF
--- a/src/app/(site)/field-notes/[slug]/opengraph-image.tsx
+++ b/src/app/(site)/field-notes/[slug]/opengraph-image.tsx
@@ -9,6 +9,56 @@ export const size = {
   height: 675, // 16:9 to match common OG previews
 }
 
+function buildAllowedImageHosts(): Set<string> {
+  const hosts = new Set<string>()
+
+  const fromEnv = process.env.OG_ALLOWED_IMAGE_HOSTS
+  if (fromEnv) {
+    for (const raw of fromEnv.split(',')) {
+      const host = raw.trim().toLowerCase()
+      if (host) hosts.add(host)
+    }
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
+  if (siteUrl) {
+    try {
+      hosts.add(new URL(siteUrl).hostname.toLowerCase())
+    } catch {
+      // ignore invalid env values
+    }
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  if (supabaseUrl) {
+    try {
+      hosts.add(new URL(supabaseUrl).hostname.toLowerCase())
+    } catch {
+      // ignore invalid env values
+    }
+  }
+
+  return hosts
+}
+
+function normalizeAndValidateOgImageUrl(raw: string): string | null {
+  const allowedHosts = buildAllowedImageHosts()
+  if (allowedHosts.size === 0) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return null
+  }
+
+  const protocol = parsed.protocol.toLowerCase()
+  if (protocol !== 'https:' && protocol !== 'http:') return null
+
+  const host = parsed.hostname.toLowerCase()
+  return allowedHosts.has(host) ? parsed.toString() : null
+}
+
 export default async function Image({
   params,
 }: {
@@ -19,6 +69,11 @@ export default async function Image({
 
   if (!note) {
     return new Response('Not found', { status: 404 })
+  }
+
+  const safeImageUrl = normalizeAndValidateOgImageUrl(note.feature_image_url)
+  if (!safeImageUrl) {
+    return new Response('Invalid OG image URL', { status: 400 })
   }
 
   return new ImageResponse(
@@ -34,7 +89,7 @@ export default async function Image({
         }}
       >
         <img
-          src={note.feature_image_url}
+          src={safeImageUrl}
           alt={note.title}
           style={{
             width: '100%',
@@ -51,5 +106,4 @@ export default async function Image({
     }
   )
 }
-
 


### PR DESCRIPTION
### Motivation

- Prevent loading untrusted remote images in the OG image renderer by enforcing a host whitelist and validating the URL format.

### Description

- Add `buildAllowedImageHosts()` to construct an allowed hosts set from `OG_ALLOWED_IMAGE_HOSTS`, `NEXT_PUBLIC_SITE_URL`, and `NEXT_PUBLIC_SUPABASE_URL` environment variables.
- Add `normalizeAndValidateOgImageUrl()` to parse, validate scheme, and ensure the image host is in the allowed set, returning `null` for invalid values.
- Return a `400` response for invalid OG image URLs and use the validated `safeImageUrl` in the rendered `ImageResponse` instead of the raw `note.feature_image_url`.

### Testing

- Ran TypeScript type checking via `tsc --noEmit` which succeeded.
- Ran the project's test suite via `yarn test` which passed.
- Performed a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9d640dd2883299a37bcaaf552a7a7)