### PR TITLE
Add selected-works route: data fetching, metadata layout, and OG image endpoint

### DIFF
--- a/src/app/(site)/selected-works/[slug]/data.ts
+++ b/src/app/(site)/selected-works/[slug]/data.ts
@@ -1,0 +1,47 @@
+import { createClient } from '@supabase/supabase-js'
+import { getAuthCookiePayload, hasPrivateAccess } from '@/lib/auth-cookie'
+
+export interface SelectedWork {
+  id: string
+  title: string
+  slug: string
+  content: string
+  feature_image_url: string
+  published_at: string
+  og_vertical_align?: 'top' | 'center' | 'bottom'
+  is_private?: boolean
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error('Supabase environment variables are not set')
+}
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+export async function getSelectedWorkBySlug(slug: string): Promise<SelectedWork | null> {
+  const { data, error } = await supabase.rpc('prod_get_selected_work_by_slug', {
+    p_slug: slug
+  })
+
+  if (error) {
+    console.error('Error fetching selected work:', error)
+    return null
+  }
+
+  if (!data || data.length === 0) {
+    return null
+  }
+
+  const work = data[0] as SelectedWork
+  if (work.is_private) {
+    const payload = await getAuthCookiePayload()
+    if (!payload || !hasPrivateAccess(payload.access_role)) {
+      return null
+    }
+  }
+
+  return work
+}

--- a/src/app/(site)/selected-works/[slug]/layout.tsx
+++ b/src/app/(site)/selected-works/[slug]/layout.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+import { getSelectedWorkBySlug } from './data'
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://levinmedia.com'
+
+function sanitizeDescription(content: string | null | undefined) {
+  if (!content) return 'Selected work'
+  const stripped = content
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#>*_`~\-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  return stripped.slice(0, 180) || 'Selected work'
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ slug: string }> }
+): Promise<Metadata> {
+  const { slug } = await params
+  const work = await getSelectedWorkBySlug(slug)
+
+  if (!work) {
+    return {
+      title: 'Selected work',
+      description: 'Selected work not found'
+    }
+  }
+
+  const description = sanitizeDescription(work.content)
+  const ogImageUrl = `${siteUrl}/selected-works/${slug}/opengraph-image`
+  const canonicalUrl = `${siteUrl}/selected-works/${slug}`
+
+  return {
+    title: work.title,
+    description,
+    openGraph: {
+      title: work.title,
+      description,
+      url: canonicalUrl,
+      type: 'article',
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: work.title
+        }
+      ]
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: work.title,
+      description,
+      images: [ogImageUrl]
+    }
+  }
+}
+
+export default function SelectedWorkLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/src/app/(site)/selected-works/[slug]/opengraph-image.tsx
+++ b/src/app/(site)/selected-works/[slug]/opengraph-image.tsx
@@ -1,0 +1,108 @@
+import { ImageResponse } from 'next/og'
+import { getSelectedWorkBySlug } from './data'
+
+export const runtime = 'nodejs'
+export const alt = 'Selected work'
+export const contentType = 'image/png'
+export const size = {
+  width: 1200,
+  height: 675,
+}
+
+function buildAllowedImageHosts(): Set<string> {
+  const hosts = new Set<string>()
+
+  const fromEnv = process.env.OG_ALLOWED_IMAGE_HOSTS
+  if (fromEnv) {
+    for (const raw of fromEnv.split(',')) {
+      const host = raw.trim().toLowerCase()
+      if (host) hosts.add(host)
+    }
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
+  if (siteUrl) {
+    try {
+      hosts.add(new URL(siteUrl).hostname.toLowerCase())
+    } catch {
+      // ignore invalid env values
+    }
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  if (supabaseUrl) {
+    try {
+      hosts.add(new URL(supabaseUrl).hostname.toLowerCase())
+    } catch {
+      // ignore invalid env values
+    }
+  }
+
+  return hosts
+}
+
+function normalizeAndValidateOgImageUrl(raw: string): string | null {
+  const allowedHosts = buildAllowedImageHosts()
+  if (allowedHosts.size === 0) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return null
+  }
+
+  const protocol = parsed.protocol.toLowerCase()
+  if (protocol !== 'https:' && protocol !== 'http:') return null
+
+  const host = parsed.hostname.toLowerCase()
+  return allowedHosts.has(host) ? parsed.toString() : null
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const work = await getSelectedWorkBySlug(slug)
+
+  if (!work) {
+    return new Response('Not found', { status: 404 })
+  }
+
+  const safeImageUrl = normalizeAndValidateOgImageUrl(work.feature_image_url)
+  if (!safeImageUrl) {
+    return new Response('Invalid OG image URL', { status: 400 })
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#0f172a',
+        }}
+      >
+        <img
+          src={safeImageUrl}
+          alt={work.title}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            objectPosition: 'center center',
+          }}
+        />
+      </div>
+    ),
+    {
+      width: size.width,
+      height: size.height,
+    }
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a dynamic `selected-works/[slug]` route that fetches selected work entries from Supabase and enforces private access checks. 
- Enable per-work metadata and generate an Open Graph image endpoint to produce shareable social previews for each selected work.

### Description
- Add `data.ts` which creates a Supabase client and implements `getSelectedWorkBySlug` to call the `prod_get_selected_work_by_slug` RPC and enforce private access using `getAuthCookiePayload` and `hasPrivateAccess`.
- Add `layout.tsx` which implements `generateMetadata` for the dynamic route, sanitizes work content for descriptions, and constructs canonical and OG metadata including a generated OG image URL.
- Add `opengraph-image.tsx` which implements a Next.js `ImageResponse` endpoint that validates and normalizes `feature_image_url` against allowed hosts from `OG_ALLOWED_IMAGE_HOSTS`, `NEXT_PUBLIC_SITE_URL`, and `NEXT_PUBLIC_SUPABASE_URL`, and returns a composed PNG image for social previews.
- Add environment validation for required Supabase variables and safe URL handling to prevent serving images from disallowed hosts.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9e78aad8c832990886b37864f2913)