### PR TITLE
Basic programs

### DIFF
--- a/docs/C64_HOME_BASIC_EXAMPLES.md
+++ b/docs/C64_HOME_BASIC_EXAMPLES.md
@@ -1,0 +1,149 @@
+# BASIC examples for the C64 home screen
+
+Type these at the **READY.** prompt. For programs with line numbers, enter **each line** and press Enter, then type **`RUN`**.
+
+One-line loops stop on their own when they hit the computer’s **step limit** (`?OUT OF STEPS`) — that’s normal.
+
+---
+
+## One-liners (then Enter)
+
+**Hello**
+
+```text
+PRINT "HELLO"
+```
+
+**Roll a six-sided die**
+
+```text
+PRINT INT(RND(1)*6)+1
+```
+
+**Is RND greater than half?** (prints `-1` for yes, `0` for no — C64-style)
+
+```text
+PRINT (RND(1)>0.5)
+```
+
+---
+
+## Classic maze (runs until step limit)
+
+```text
+10 PRINT CHR$(205.5+RND(1)); : GOTO 10
+```
+
+`RUN` — dense random slashes.  
+`NEW` when you want to clear the program from memory.
+
+---
+
+## Tighter random slashes (biased)
+
+Favors one diagonal a bit more than the other:
+
+```text
+10 PRINT CHR$(205.5+(RND(1)^2)); : GOTO 10
+```
+
+---
+
+## Three-character chaos
+
+Picks among three PETSCII codes in a row:
+
+```text
+10 PRINT CHR$(205+INT(RND(1)*3)); : GOTO 10
+```
+
+---
+
+## Small banner (one logical row)
+
+Prints a row of stars, then a newline. Finishes immediately — no infinite loop.
+
+```text
+10 FOR X=1 TO 24
+20 PRINT "*";
+30 NEXT X
+40 PRINT
+```
+
+`RUN`
+
+---
+
+## Mini “screen” block (rows of dots)
+
+Outer loop = rows, inner = columns. Each row ends with `PRINT` (blank `PRINT` = newline only after the row of semicolon-printed chars).
+
+```text
+10 FOR Y=1 TO 8
+20 FOR X=1 TO 16
+30 PRINT ".";
+40 NEXT X
+50 PRINT
+60 NEXT Y
+```
+
+`RUN`
+
+---
+
+## Wave stripe (sine picks between two characters)
+
+Uses a counter in `Y`; `SIN` is in **radians**.
+
+```text
+10 Y=0
+20 FOR I=1 TO 80
+30 Y=Y+1
+40 PRINT CHR$(205.5+(SIN(Y/5)>0));
+50 NEXT I
+60 PRINT
+```
+
+`RUN`
+
+---
+
+## Random branches
+
+Jumps to different “verses” depending on `INT(RND(1)*3)`:
+
+```text
+10 A=INT(RND(1)*3)
+20 IF A=0 THEN 100
+30 IF A=1 THEN 110
+40 GOTO 120
+100 PRINT "PATH A"
+105 GOTO 200
+110 PRINT "PATH B"
+115 GOTO 200
+120 PRINT "PATH C"
+200 PRINT "DONE"
+```
+
+`RUN` a few times to see different paths.
+
+---
+
+## Countdown with FOR
+
+```text
+10 FOR T=5 TO 1 STEP -1
+20 PRINT T
+30 NEXT T
+40 PRINT "GO"
+```
+
+`RUN`
+
+---
+
+## Tips
+
+- **`LIST`** — see your program. **`NEW`** — erase it. **`RUN`** — start from the lowest line number.
+- **`;`** after `PRINT` keeps the next character on the **same** logical line; **`PRINT` alone** starts a new line in the log.
+- More syntax and limits: **`C64_TERMINAL_BASIC.md`**. Visitor overview: **`C64_HOME_USER_GUIDE.md`**.

--- a/docs/C64_HOME_USER_GUIDE.md
+++ b/docs/C64_HOME_USER_GUIDE.md
@@ -1,0 +1,67 @@
+# What you can do on the C64 home screen
+
+The portfolio home can look and feel like a Commodore 64: disk catalog, `LOAD` / `RUN`, and a **BASIC prompt** where you type small programs. This page is for **you** as a visitor or owner — not for programmers maintaining the code.
+
+---
+
+## The short version
+
+You can **type commands** as if the machine is real: load fake disk programs, list the “directory,” and write **tiny BASIC programs** that print patterns, random art, and experiments. Output scrolls in a long log (like a modern terminal), so think “creative playground,” not a fixed TV-sized grid.
+
+---
+
+## Things you can try without writing a program
+
+- **Open disk entries** — Pick a program from the list (or type the `LOAD "NAME",8,1` style command and `RUN`) to open About, work, notes, and the rest of the site in drawer panels.
+- **Disk catalog** — The directory is the **clickable list** above the prompt (or type `LOAD "NAME",8,1` and `RUN`). With **no BASIC program in memory**, `LIST` logs `LIST` / `READY.` and scrolls to that list again (after `LOAD "$",8`, after loading a PRG, or anytime). The catalog is not pasted as plain text into the log. Closing a drawer can auto-type `LIST` the same way.
+- **Clear the program in memory** — Type `NEW` to wipe any BASIC lines you’ve stored.
+- **See what you stored** — Type `LIST` to show your current program lines.
+
+---
+
+## Things you can do with BASIC
+
+Once you’re entering **numbered lines** (e.g. `10 PRINT "HI"`), you’re in “program mode.” Type `RUN` to execute.
+
+### Make noise on screen
+
+- **Classic maze** — A one-liner that keeps printing random slash-like characters until the computer stops it (there’s a safety limit so your browser never freezes).
+- **Glitch fields** — Loops that print random symbols and blocks (PETSCII-style characters) for a dense, retro texture.
+- **Stripes and waves** — Use math inside `CHR$(…)` so the character choice follows a sine-like pattern — calmer than pure random.
+- **Banners** — Nested loops to print rows of stars, dashes, or mixed characters, one row per line.
+
+### Play with randomness
+
+- **Skewed random** — Favor one “look” over another so streaks appear instead of perfect noise.
+- **Dice-style values** — Use `INT` and `RND` to pick integers in a range and print them or turn them into characters.
+
+### Light logic
+
+- **Variables** — Single letters `A` through `Z` hold numbers; you can update them each loop.
+- **Branches** — `IF` something `THEN` a line number jumps around your program (good for “pick A, B, or C path”).
+- **Loops** — `FOR` / `NEXT` for counted loops; you can nest them (loop inside a loop).
+
+### Combine tricks
+
+Mix **PRINT**, **semicolons** (stay on the same line), **PRINT** alone (new line), **GOTO**, **IF**, and **FOR** to build little “demos” that run for a few seconds and fill the log with something you designed.
+
+---
+
+## What to expect (so nothing feels “broken”)
+
+- **It will stop on its own** if a loop runs too long — you’ll see `?OUT OF STEPS`. Start again or simplify the loop.
+- **The line may wrap** on a phone or narrow window — that’s the browser fitting text; your program still thinks in “print this, then newline.”
+- **Stopping a run** — **Escape** on a keyboard, or the on-screen **STOP** control on touch, while a program is running.
+- **Not a full C64** — There’s no `INPUT` from inside a program, no string variables like `A$`, no `GOSUB`. If something isn’t listed above, assume it isn’t there yet.
+
+---
+
+## Where the nerdy details live
+
+**`C64_HOME_BASIC_EXAMPLES.md`** — small programs you can type and run (maze, banners, waves, dice, and more).
+
+For exact rules (every statement, limits, and technical notes), see **`C64_TERMINAL_BASIC.md`** in the same folder — that one is the “reference manual.” **This** file is the “what can I do?” answer.
+
+---
+
+*Have fun; the point is to mess with the machine a little before you wander into the rest of the site.*

--- a/docs/C64_TERMINAL_BASIC.md
+++ b/docs/C64_TERMINAL_BASIC.md
@@ -1,0 +1,123 @@
+# C64 home terminal — BASIC pocket manual
+
+For a **visitor-friendly** “what can I do here?” overview, see **`C64_HOME_USER_GUIDE.md`**. **Copy-paste examples:** **`C64_HOME_BASIC_EXAMPLES.md`**.
+
+This is the dialect implemented in `src/lib/c64-basic.ts` for the authentic C64 home screen. It is **not** a full Commodore 64 BASIC V2 interpreter; it is a small, browser-safe subset with a C64 feel.
+
+---
+
+## How you use it
+
+- **Numbered lines** — Type `10 PRINT "HELLO"`, Enter. The line is stored; there is no `READY.` after each stored line (unlike typing at the real C64 immediate mode).
+- **LIST** — With a stored program, prints those lines in the log. With **no** program lines, logs `LIST` / `READY.` and scrolls to the **clickable disk directory** above the prompt (after `LOAD "$",8`, after a PRG `LOAD`, or anytime — not pasted as plain text).
+- **NEW** — Clears the stored program.
+- **RUN** — Runs from the lowest line number (or continues after `LOAD` / `RUN` flows from the disk UI).
+- **GOTO n** — Direct or inside a program; target line must exist or you get `?UNDEF'D STATEMENT ERROR`.
+- **Colon** — Several statements on one line: `PRINT "A": GOTO 10`. **Exception:** a line that contains **FOR** or **NEXT** must contain **only** that one statement (no `:` on that line).
+- **Step limit** — Long tight loops stop with `?OUT OF STEPS` (default 10 000 steps) so the tab cannot hang.
+- **Stop** — While a program runs: **Escape** on desktop; **[STOP]** on touch. **PRINT** during a run streams into the log; the “screen” is one wide scrolling terminal, not a fixed 40×25 hardware matrix. Use **PRINT** alone for a newline between **logical** rows; the browser may still wrap a long line visually.
+
+---
+
+## What’s in the language
+
+| Feature | Notes |
+|--------|--------|
+| **PRINT** | Strings in `"..."` (shown in uppercase). Numbers print as-is. |
+| **`;`** | Stay on the same logical line (no newline at end of PRINT). |
+| **`,`** | Inserts a two-space field (C64-ish spacing). |
+| **CHR$(n)** | One character from PETSCII value `n` (see below). |
+| **RND(x)** | `x > 0`: next random in (0,1). `x = 0`: repeat last. `x < 0`: reseed, then value. |
+| **INT(x)** | Floor toward −∞ (C64-style). |
+| **SIN(x)**, **COS(x)** | Radians. |
+| **^** | Power, **right-associative**. *Not* on stock C64 BASIC V2; included for short demos. |
+| **Comparisons** | `=`, `<>`, `<`, `>`, `<=`, `>=` in expressions yield **−1** (true) or **0** (false), like C64 numeric compares. |
+| **+ − * /** | With parentheses as usual. |
+| **Variables** | Single letters **A–Z** only. **LET** optional: `LET A=1` or `A=1`. Unread variables are **0**. |
+| **IF expr THEN line** | If expression ≠ 0, jump to **line**; if 0, fall through. **Only** `THEN <line number>` — not `THEN PRINT …`. After a false IF, the rest of the **same** physical line after `:` still runs. |
+| **FOR / NEXT** | `FOR I = start TO limit [STEP step]`, `NEXT` or `NEXT I`. Nested loops OK. **One statement per line** for any line that has FOR or NEXT. **STEP 0** is an error. |
+| **GOTO** | Same line or elsewhere. |
+
+---
+
+## PETSCII and CHR$
+
+Non-ASCII codes use the **Style64 “uppercase / graphics” mapping** (private use area **U+E000 + byte**) so **C64 Pro Mono** draws the right glyphs. ASCII **32–126** print as normal ASCII. The classic maze one-liner uses **205** and **206** (diagonals) with `CHR$(205.5+RND(1))`.
+
+You can still think in **PETSCII ranges** for glitch art, bars, and block characters — not only mazes.
+
+---
+
+## Ideas beyond the maze one-liner
+
+All of these fit what you have **today** (maybe within the step limit).
+
+### Output and “graphics”
+
+- **Random PETSCII fields** — `CHR$(200+INT(RND(1)*40))` style loops to fill the log with blocks, lines, and symbols.
+- **Deterministic art** — Use `SIN` / `COS` on a counter in a FOR loop to pick between two or three CHR$ codes (waves, stripes, “circuit” patterns).
+- **Biased randomness** — `(RND(1)>0.7)` or `(RND(1)^2)` inside a CHR$ expression to skew which character appears (streakier noise).
+- **Banners** — Nested FORs to print rows of the same character, or alternating characters, then `PRINT` for a newline each row.
+- **Progressive density** — A variable `P` updated each step (`P=P+(RND(1)-.5)/10` with clamps via IF) to change how often you pick one glyph vs another (needs a few lines of assigns + IF).
+
+### Numbers and toys
+
+- **Dice / ranges** — `INT(RND(1)*6)+1` for 1..6; print many times in a loop for a histogram of text characters.
+- **Comparisons as arithmetic** — `205.5+(RND(1)>0.5)` style tricks map booleans into CHR$ bands.
+- **Mini state machines** — Variables hold “mode” or position; **IF … THEN** jumps to different line blocks (menu-like, not interactive input).
+
+### Structure and “demos”
+
+- **Multiple sections** — `GOTO` chains: init block, draw block, delay loop (FOR…NEXT with empty body or PRINT), repeat.
+- **Entry point** — `RUN` always starts at the smallest line number; use `IF 1 THEN 100` on line 10 to skip to a “main” label at 100 if you like that style.
+- **Clear and redraw** — `NEW` from the user clears program; from code you can’t call NEW, but you can branch to a “clear output” strategy by PRINTing blank lines or separators (strings of spaces or dashes).
+
+### What you cannot do yet
+
+- **INPUT**, **GET**, **INPUT#** — no keyboard input inside a running program.
+- **String variables** (`A$`), **arrays**, **DEF FN**, **ON GOTO**, **GOSUB/RETURN**.
+- **PEEK/POKE**, **WAIT**, **SYS** — no machine.
+- **Multi-statement** `IF THEN PRINT …` — only `THEN line`.
+- **FOR … : PRINT … : NEXT** on one line — FOR/NEXT lines must be alone.
+
+---
+
+## Sample skeletons (patterns, not copy-paste gospel)
+
+**One-line infinite texture (until step cap):**
+
+```text
+10 PRINT CHR$(205.5+RND(1)); : GOTO 10
+```
+
+**Row of 40 glyphs then newline (logical row; may wrap on narrow viewports):**
+
+```text
+10 FOR X=1 TO 40
+20 PRINT "*";
+30 NEXT X
+40 PRINT
+```
+
+**Branching “modes” (line numbers are examples):**
+
+```text
+10 A=INT(RND(1)*3)
+20 IF A=0 THEN 100
+30 IF A=1 THEN 200
+40 GOTO 300
+```
+
+---
+
+## Files and limits
+
+- Implementation: **`src/lib/c64-basic.ts`**
+- Tests: **`src/lib/c64-basic.test.ts`**
+- Step cap constant: **`BASIC_MAX_STEPS`** (10 000)
+
+When something fails, you’ll see familiar C64-style messages such as `?SYNTAX ERROR`, `?UNDEF'D STATEMENT ERROR`, `?OUT OF STEPS`, or `?NEXT WITHOUT FOR`.
+
+---
+
+*Treat this as a creative constraint set: short programs, visible output, and a CRT that scrolls like a modern log — with C64 typography and PETSCII when you reach for CHR$.*

--- a/docs/C64_TERMINAL_BASIC.md
+++ b/docs/C64_TERMINAL_BASIC.md
@@ -9,7 +9,7 @@ This is the dialect implemented in `src/lib/c64-basic.ts` for the authentic C64 
 ## How you use it
 
 - **Numbered lines** — Type `10 PRINT "HELLO"`, Enter. The line is stored; there is no `READY.` after each stored line (unlike typing at the real C64 immediate mode).
-- **LIST** — With a stored program, prints those lines in the log. With **no** program lines, logs `LIST` / `READY.` and scrolls to the **clickable disk directory** above the prompt (after `LOAD "$",8`, after a PRG `LOAD`, or anytime — not pasted as plain text).
+- **LIST** — With a stored program, prints those lines in the log. With **no** program lines, logs `LIST` / `READY.` and scrolls to the **clickable disk directory** above the prompt (after `LOAD "$",8`, after a PRG `LOAD`, or anytime — not pasted as plain text). Typing **`LOAD "$",8`** (or `LOAD"$",8`) **clears** the stored program, like a real directory load overwriting BASIC memory, so the next **LIST** can show the disk.
 - **NEW** — Clears the stored program.
 - **RUN** — Runs from the lowest line number (or continues after `LOAD` / `RUN` flows from the disk UI).
 - **GOTO n** — Direct or inside a program; target line must exist or you get `?UNDEF'D STATEMENT ERROR`.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:unit": "vitest run --project unit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -26,6 +26,11 @@ const C64_INLINE_INIT = `
   el.style.setProperty('--c64-text-scale',scale);
   el.dataset.c64Scanlines=s.scanlines?'on':'off';
   el.dataset.c64Boot=s.boot||'session';
+  try{
+    if(sessionStorage.getItem('c64-session-entry-path')==null){
+      sessionStorage.setItem('c64-session-entry-path',location.pathname||'/');
+    }
+  }catch(e){}
 })();
 `
 

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -14,7 +14,7 @@ const C64_INLINE_INIT = `
   var TABLE=${C64_INLINE_THEME_VARS_JSON};
   var el=document.getElementById('c64-site-root');
   if(!el)return;
-  var def={accent:'classic',screenTint:'default',scanlines:false,boot:'session',textScale:'comfortable'};
+  var def={accent:'classic',screenTint:'default',scanlines:true,boot:'session',textScale:'comfortable'};
   var s=def;
   try{var r=localStorage.getItem('site-c64-settings');if(r)s=Object.assign({},def,JSON.parse(r));}catch(e){}
   if(s.accent==='cyan'||s.accent==='lightblue')s.accent='classic';

--- a/src/app/components/C64AuthenticHomeScreen.tsx
+++ b/src/app/components/C64AuthenticHomeScreen.tsx
@@ -1,10 +1,17 @@
 'use client'
 
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import { useSearchParams } from 'next/navigation'
 import type { ClipboardEvent, KeyboardEvent, ReactNode, RefObject } from 'react'
 import {
   C64_HOME_BOOT_LINES_SESSION_KEY,
+  C64_SESSION_ENTRY_PATH_KEY,
   loadC64Settings,
 } from '@/lib/c64-settings'
 import type { BasicOutputOp } from '@/lib/c64-basic'
@@ -1099,7 +1106,34 @@ export default function C64AuthenticHomeScreen({
     schedule(step, LOAD_TYPEWRITER_MS)
   }
 
+  /**
+   * First full load of the tab was not `/` → wait until no site drawer covers the CRT, then run boot
+   * once so the sequence is visible the first time they reach a clear home.
+   */
+  const sessionEntryWasNotHomeRef = useRef<boolean | null>(null)
+  useLayoutEffect(() => {
+    if (sessionEntryWasNotHomeRef.current !== null) {
+      return
+    }
+    try {
+      const p = sessionStorage.getItem(C64_SESSION_ENTRY_PATH_KEY) ?? '/'
+      sessionEntryWasNotHomeRef.current = p !== '/' && p !== ''
+    } catch {
+      sessionEntryWasNotHomeRef.current = false
+    }
+  }, [])
+
+  const authenticBootStartedRef = useRef(false)
+
+  /** Landed on `/` first: boot immediately (may run under a query-param drawer). */
   useEffect(() => {
+    if (sessionEntryWasNotHomeRef.current === true) {
+      return undefined
+    }
+    if (authenticBootStartedRef.current) {
+      return undefined
+    }
+
     const settings = loadC64Settings()
     const reduced =
       typeof window !== 'undefined' &&
@@ -1114,21 +1148,25 @@ export default function C64AuthenticHomeScreen({
     }
 
     if (settings.boot === 'off' || reduced) {
+      authenticBootStartedRef.current = true
       skipToCompleteBoot()
-      return
+      return undefined
     }
 
     if (settings.boot === 'session') {
       try {
         if (sessionStorage.getItem(C64_HOME_BOOT_LINES_SESSION_KEY)) {
+          authenticBootStartedRef.current = true
           skipToCompleteBoot()
-          return
+          return undefined
         }
       } catch {
         // ignore
       }
     }
 
+    authenticBootStartedRef.current = true
+    let bootFinishedLatch = false
     const timeouts: number[] = []
     let cancelled = false
 
@@ -1142,6 +1180,7 @@ export default function C64AuthenticHomeScreen({
     }
 
     const finishBoot = () => {
+      bootFinishedLatch = true
       if (settings.boot === 'session') {
         try {
           sessionStorage.setItem(C64_HOME_BOOT_LINES_SESSION_KEY, '1')
@@ -1235,8 +1274,169 @@ export default function C64AuthenticHomeScreen({
       for (const id of timeouts) {
         window.clearTimeout(id)
       }
+      if (!bootFinishedLatch) {
+        authenticBootStartedRef.current = false
+      }
     }
   }, [])
+
+  useEffect(() => {
+    const notHomeFirst = sessionEntryWasNotHomeRef.current === true
+    if (!notHomeFirst) {
+      return undefined
+    }
+    if (authenticBootStartedRef.current) {
+      return undefined
+    }
+    if (drawerOpen) {
+      return undefined
+    }
+
+    const settings = loadC64Settings()
+    const reduced =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    const skipToCompleteBoot = () => {
+      setLinesShown(CENTER_STAGE_COUNT)
+      setDiskCompletedLines([...DISK_SEQUENCE_LINES])
+      setDiskTyping(null)
+      setDiskSpinnerGlyph(null)
+      setBootComplete(true)
+    }
+
+    if (settings.boot === 'off' || reduced) {
+      authenticBootStartedRef.current = true
+      skipToCompleteBoot()
+      return undefined
+    }
+
+    if (settings.boot === 'session') {
+      try {
+        if (sessionStorage.getItem(C64_HOME_BOOT_LINES_SESSION_KEY)) {
+          authenticBootStartedRef.current = true
+          skipToCompleteBoot()
+          return undefined
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    authenticBootStartedRef.current = true
+    let bootFinishedLatch = false
+
+    const timeouts: number[] = []
+    let cancelled = false
+
+    const after = (ms: number, fn: () => void) => {
+      const id = window.setTimeout(() => {
+        if (!cancelled) {
+          fn()
+        }
+      }, ms) as unknown as number
+      timeouts.push(id)
+    }
+
+    const finishBoot = () => {
+      bootFinishedLatch = true
+      if (settings.boot === 'session') {
+        try {
+          sessionStorage.setItem(C64_HOME_BOOT_LINES_SESSION_KEY, '1')
+        } catch {
+          // ignore
+        }
+      }
+      setBootComplete(true)
+    }
+
+    const runDiskLine = (lineIndex: number) => {
+      if (cancelled) {
+        return
+      }
+      if (lineIndex >= DISK_SEQUENCE_LINES.length) {
+        finishBoot()
+        return
+      }
+      const text = DISK_SEQUENCE_LINES[lineIndex]
+      if (text === '') {
+        setDiskCompletedLines((prev) => [...prev, ''])
+        after(DISK_BLANK_LINE_PAUSE_MS, () => runDiskLine(lineIndex + 1))
+        return
+      }
+
+      let visible = 0
+      setDiskTyping({ line: text, count: 0 })
+
+      const typeStep = () => {
+        if (cancelled) {
+          return
+        }
+        visible += 1
+        setDiskTyping({ line: text, count: visible })
+        if (visible < text.length) {
+          after(DISK_TYPE_MS, typeStep)
+        } else {
+          after(DISK_TYPE_MS, () => {
+            if (cancelled) {
+              return
+            }
+            if (text === 'LOADING') {
+              const runSpinFrame = (frame: number) => {
+                if (cancelled) {
+                  return
+                }
+                setDiskTyping({ line: text, count: text.length })
+                setDiskSpinnerGlyph(DISK_SPIN_CHARS[frame % DISK_SPIN_CHARS.length])
+                if (frame + 1 < DISK_SPIN_FRAME_COUNT) {
+                  after(DISK_SPIN_FRAME_MS, () => runSpinFrame(frame + 1))
+                } else {
+                  setDiskSpinnerGlyph(null)
+                  setDiskCompletedLines((prev) => [...prev, text])
+                  setDiskTyping(null)
+                  const pauseAfter =
+                    DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 320
+                  after(pauseAfter, () => runDiskLine(lineIndex + 1))
+                }
+              }
+              runSpinFrame(0)
+              return
+            }
+            setDiskCompletedLines((prev) => [...prev, text])
+            setDiskTyping(null)
+            const pauseAfter =
+              DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 320
+            if (lineIndex < DISK_SEQUENCE_LINES.length - 1) {
+              after(pauseAfter, () => runDiskLine(lineIndex + 1))
+            } else {
+              after(pauseAfter, finishBoot)
+            }
+          })
+        }
+      }
+
+      after(DISK_TYPE_MS, typeStep)
+    }
+
+    setLinesShown(1)
+    after(ROM_PAUSE_MS_AFTER_LINE[0] ?? 220, () => {
+      setLinesShown(2)
+      after(ROM_PAUSE_MS_AFTER_LINE[1] ?? 200, () => {
+        setLinesShown(3)
+        after(ROM_PAUSE_MS_AFTER_LINE[2] ?? 360, () => runDiskLine(0))
+      })
+    })
+
+    return () => {
+      cancelled = true
+      for (const id of timeouts) {
+        window.clearTimeout(id)
+      }
+      if (!bootFinishedLatch) {
+        authenticBootStartedRef.current = false
+      }
+    }
+  }, [drawerOpen])
 
   terminalSubmitRef.current = (nextRaw: string) => {
     const next = nextRaw.replace(/\r/g, '').trim()

--- a/src/app/components/C64AuthenticHomeScreen.tsx
+++ b/src/app/components/C64AuthenticHomeScreen.tsx
@@ -1,12 +1,52 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
-import type { KeyboardEvent, ReactNode, RefObject } from 'react'
+import type { ClipboardEvent, KeyboardEvent, ReactNode, RefObject } from 'react'
 import {
   C64_HOME_BOOT_LINES_SESSION_KEY,
   loadC64Settings,
 } from '@/lib/c64-settings'
+import type { BasicOutputOp } from '@/lib/c64-basic'
+import {
+  createBasicProgram,
+  formatProgramLineEcho,
+  isDirectList,
+  isDirectNew,
+  isDirectRun,
+  listProgram,
+  normalizeInputLine,
+  resetDirectEvalContext,
+  runBasicProgram,
+  storeProgramLine,
+  tryDirectGoto,
+  tryDirectPrint,
+  tryParseProgramLine,
+} from '@/lib/c64-basic'
+
+function applyBasicOutputOps(
+  ops: BasicOutputOp[],
+  appendRows: (texts: string[]) => void,
+): void {
+  let buf = ''
+  for (const op of ops) {
+    if (op.op === 'append') {
+      buf += op.text
+    } else if (op.op === 'newline') {
+      appendRows([buf])
+      buf = ''
+    } else if (op.op === 'lines') {
+      if (buf.length > 0) {
+        appendRows([buf])
+        buf = ''
+      }
+      appendRows(op.texts)
+    }
+  }
+  if (buf.length > 0) {
+    appendRows([buf])
+  }
+}
 
 /**
  * Home-only layout: classic C64 CRT (no site nav, no howdy).
@@ -150,6 +190,81 @@ const LOAD_LABEL_TO_ACTION: Record<string, keyof C64HomeCommandHandlers> = {
   SETTINGS: 'onOpenSiteSettings',
 }
 
+/** LOAD "$",8 / LOAD"$",8 — read $ directory (no ,1). Case-insensitive. */
+function isLoadDiskCatalogCommand(line: string): boolean {
+  const t = line.replace(/\r/g, '').trim()
+  return /^\s*LOAD\s*"\$"\s*,\s*8\s*$/i.test(t)
+}
+
+/** CRT scrollback line, or an embedded clickable disk catalog (LIST with no BASIC program). */
+export type C64TerminalHistoryRow =
+  | { id: number; kind: 'text'; text: string }
+  | { id: number; kind: 'disk-catalog' }
+
+function c64TextRow(id: number, text: string): C64TerminalHistoryRow {
+  return { id, kind: 'text', text }
+}
+
+/** Same rows as the main directory block, rendered inside the terminal log after LIST. */
+function TerminalDiskCatalogEmbed({
+  blockId,
+  onPlayLoad,
+  onProgramKeyDown,
+}: {
+  blockId: number
+  onPlayLoad: (action: keyof C64HomeCommandHandlers) => void
+  onProgramKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
+}) {
+  return (
+    <div
+      className="c64-terminal-disk-catalog m-0 my-2 w-full max-w-full"
+      role="region"
+      aria-label="Disk directory from LIST"
+    >
+      <div className="c64-dir-header text-xs sm:text-base md:text-lg leading-tight tracking-wide py-1.5 rounded-sm w-fit max-w-full">
+        {DISK_VOLUME_LINE}
+      </div>
+      <nav
+        className="c64-dir-table text-xs sm:text-base md:text-lg leading-tight tracking-wide mt-1 w-max max-w-full"
+        aria-label="Disk programs from LIST"
+      >
+        {DIRECTORY_ROWS.map((row, i) =>
+          row.kind === 'del' ? (
+            <div
+              key={`tc-${blockId}-del-${i}`}
+              className="c64-dir-row c64-dir-row--static text-[var(--c64-crt-ink-dim)]"
+            >
+              <span className="c64-dir-blocks tabular-nums">0</span>
+              <span className="c64-dir-name min-w-0 truncate">
+                &quot;----------------&quot;
+              </span>
+              <span className="c64-dir-type">DEL</span>
+            </div>
+          ) : (
+            <button
+              key={`tc-${blockId}-${row.action}`}
+              type="button"
+              onClick={() => onPlayLoad(row.action)}
+              onKeyDown={onProgramKeyDown}
+              className="c64-dir-row c64-dir-row--prg w-full text-left border-0 rounded-none"
+              aria-label={`Load ${LOAD_COMMAND_BY_ACTION[row.action]} and open ${row.name}`}
+            >
+              <span className="c64-dir-blocks tabular-nums">{row.blocks}</span>
+              <span className="c64-dir-name min-w-0 truncate">
+                &quot;{row.name}&quot;
+              </span>
+              <span className="c64-dir-type">PRG</span>
+            </button>
+          ),
+        )}
+      </nav>
+      <div className="c64-dir-footer text-xs sm:text-base md:text-lg leading-tight tracking-wide mt-3 text-[var(--c64-crt-ink)]">
+        <p className="m-0">{DIRECTORY_BLOCKS_FREE} BLOCKS FREE.</p>
+      </div>
+    </div>
+  )
+}
+
 const LOAD_TYPEWRITER_MS = 42
 const LOAD_AFTER_TYPED_PAUSE_MS = 140
 
@@ -201,10 +316,10 @@ export default function C64AuthenticHomeScreen({
   const [bootComplete, setBootComplete] = useState(false)
 
   /** Lines committed with Enter below READY. (typed text stays visible). */
-  const [terminalHistory, setTerminalHistory] = useState<{ id: number; text: string }[]>(
-    [],
-  )
+  const [terminalHistory, setTerminalHistory] = useState<C64TerminalHistoryRow[]>([])
   const [terminalLine, setTerminalLine] = useState('')
+  /** Caret index in `terminalLine` (0…length); mirrored to ghost input when editable. */
+  const [terminalCaretPos, setTerminalCaretPos] = useState(0)
   const [terminalAutoTyping, setTerminalAutoTyping] = useState(false)
   /** True while blank → SEARCHING → LOADING spinner; input locked. */
   const [terminalSequenceBusy, setTerminalSequenceBusy] = useState(false)
@@ -218,6 +333,19 @@ export default function C64AuthenticHomeScreen({
   const [terminalLoadingGlyph, setTerminalLoadingGlyph] = useState<string | null>(
     null,
   )
+  const [basicRunning, setBasicRunning] = useState(false)
+  const basicRunningRef = useRef(false)
+  /** Show on-screen [STOP] only on phones / coarse-pointer tablets (desktop uses Escape). */
+  const [basicStopTouchUi, setBasicStopTouchUi] = useState(false)
+  const basicProgramRef = useRef(createBasicProgram())
+  /** After manual LOAD "$",8 finishes, LIST prints the disk catalog in the terminal log. */
+  const [diskCatalogReady, setDiskCatalogReady] = useState(false)
+  const basicAbortRef = useRef<AbortController | null>(null)
+  /** One terminal row that grows while PRINT uses `;` (no newline yet). */
+  const basicLivePrintRowIdRef = useRef<number | null>(null)
+  const basicPrintRafRef = useRef<number | null>(null)
+  /** Latest “replay LIST after drawer” impl (ref so drawer timeout always calls current). */
+  const playDiskListReplayRef = useRef<() => void>(() => {})
   const terminalLineIdRef = useRef(0)
   const terminalTypewriterRunIdRef = useRef(0)
   const terminalTypewriterTimeoutRef = useRef<number | undefined>(undefined)
@@ -227,9 +355,13 @@ export default function C64AuthenticHomeScreen({
   const terminalLoadTimeoutsRef = useRef<number[]>([])
 
   const scrollViewportRef = useRef<HTMLDivElement>(null)
+  /** Scroll target when LIST shows the $ catalog (clickable rows live here, not in the log). */
+  const diskListingRef = useRef<HTMLDivElement>(null)
   const terminalInputRef = useRef<HTMLInputElement>(null)
+  /** Same behavior as Enter; used for multi-line paste into the ghost input. */
+  const terminalSubmitRef = useRef<(next: string) => void>(() => {})
   const diskLogKey = diskCompletedLines.join('\n')
-  const terminalScrollKey = `${terminalHistory.map((h) => h.text).join('\n')}\n${terminalLine}\n${terminalLoadingGlyph ?? ''}\n${terminalSequenceBusy}\n${terminalPendingRun ? 'p' : ''}`
+  const terminalScrollKey = `${terminalHistory.map((h) => (h.kind === 'text' ? h.text : '[disk]')).join('\n')}\n${terminalLine}\n${terminalLoadingGlyph ?? ''}\n${terminalSequenceBusy}\n${terminalPendingRun ? 'p' : ''}\n${basicRunning ? 'b' : ''}\n${diskCatalogReady ? 'c' : 'C'}`
 
   useLayoutEffect(() => {
     const el = scrollViewportRef.current
@@ -259,6 +391,63 @@ export default function C64AuthenticHomeScreen({
   }, [terminalSequenceBusy])
 
   useEffect(() => {
+    basicRunningRef.current = basicRunning
+  }, [basicRunning])
+
+  const terminalInputBusy =
+    terminalAutoTyping || terminalSequenceBusy || basicRunning
+  /** Caret index for drawing the prompt (always end while input is read-only). */
+  const terminalPromptCaretPos = terminalInputBusy
+    ? terminalLine.length
+    : Math.min(terminalCaretPos, terminalLine.length)
+
+  const syncTerminalCaretFromInput = useCallback(
+    (el: HTMLInputElement) => {
+      if (terminalAutoTyping || terminalSequenceBusy || basicRunning) {
+        return
+      }
+      const raw = el.selectionStart ?? 0
+      const clamped = Math.min(Math.max(0, raw), el.value.length)
+      setTerminalCaretPos(clamped)
+    },
+    [terminalAutoTyping, terminalSequenceBusy, basicRunning],
+  )
+
+  /** Keep ghost input selection and caret index aligned with the visible prompt (controlled input). */
+  useLayoutEffect(() => {
+    const el = terminalInputRef.current
+    const len = terminalLine.length
+
+    if (terminalInputBusy) {
+      setTerminalCaretPos(len)
+      if (el && document.activeElement === el) {
+        el.setSelectionRange(len, len)
+      }
+      return
+    }
+
+    const c = Math.min(terminalCaretPos, len)
+    if (c !== terminalCaretPos) {
+      setTerminalCaretPos(c)
+    }
+    if (el && document.activeElement === el) {
+      el.setSelectionRange(c, c)
+    }
+  }, [
+    terminalLine,
+    terminalCaretPos,
+    terminalInputBusy,
+  ])
+
+  useEffect(() => {
+    const mq = window.matchMedia('(hover: none) and (pointer: coarse)')
+    const sync = () => setBasicStopTouchUi(mq.matches)
+    sync()
+    mq.addEventListener('change', sync)
+    return () => mq.removeEventListener('change', sync)
+  }, [])
+
+  useEffect(() => {
     if (!bootComplete) {
       return
     }
@@ -268,7 +457,10 @@ export default function C64AuthenticHomeScreen({
     return () => window.clearTimeout(id)
   }, [bootComplete])
 
-  /** Drawers focus-trap steals the prompt; put it back when a panel closes. */
+  /**
+   * When a site drawer closes, replay loading the disk catalog (LOAD"$",8 → SEARCHING → LOADING →
+   * READY.) then LIST + clickable directory embed + READY. Skip if terminal is busy or BASIC runs.
+   */
   useEffect(() => {
     if (!bootComplete) {
       return
@@ -278,9 +470,18 @@ export default function C64AuthenticHomeScreen({
     if (wasOpen && !drawerOpen) {
       const id = window.setTimeout(() => {
         if (terminalAutoTypingRef.current || terminalSequenceBusyRef.current) {
+          window.requestAnimationFrame(() => {
+            focusC64TerminalInput(terminalInputRef)
+          })
           return
         }
-        focusC64TerminalInput(terminalInputRef)
+        if (basicRunningRef.current) {
+          window.requestAnimationFrame(() => {
+            focusC64TerminalInput(terminalInputRef)
+          })
+          return
+        }
+        playDiskListReplayRef.current()
       }, 200)
       return () => window.clearTimeout(id)
     }
@@ -289,6 +490,12 @@ export default function C64AuthenticHomeScreen({
 
   useEffect(() => {
     return () => {
+      if (basicPrintRafRef.current !== null) {
+        cancelAnimationFrame(basicPrintRafRef.current)
+        basicPrintRafRef.current = null
+      }
+      basicLivePrintRowIdRef.current = null
+      basicAbortRef.current?.abort()
       terminalTypewriterRunIdRef.current += 1
       if (terminalTypewriterTimeoutRef.current !== undefined) {
         window.clearTimeout(terminalTypewriterTimeoutRef.current)
@@ -300,6 +507,32 @@ export default function C64AuthenticHomeScreen({
       terminalLoadTimeoutsRef.current = []
     }
   }, [])
+
+  /**
+   * Escape: abort BASIC when running; otherwise clear disk-catalog LIST readiness so you can retype
+   * LOAD "$",8 then LIST (drawer keeps Escape for closing panels).
+   */
+  useEffect(() => {
+    if (drawerOpen) {
+      return undefined
+    }
+    const onKeyDown = (ev: globalThis.KeyboardEvent) => {
+      if (ev.key !== 'Escape') {
+        return
+      }
+      if (basicRunning) {
+        ev.preventDefault()
+        basicAbortRef.current?.abort()
+        return
+      }
+      if (terminalSequenceBusyRef.current || terminalAutoTypingRef.current) {
+        return
+      }
+      setDiskCatalogReady(false)
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => document.removeEventListener('keydown', onKeyDown, true)
+  }, [basicRunning, drawerOpen])
 
   const handlers: Record<keyof C64HomeCommandHandlers, () => void> = {
     onOpenAbout,
@@ -335,6 +568,143 @@ export default function C64AuthenticHomeScreen({
   const searchLabelFromLoadCommand = (cmd: string) => {
     const m = /LOAD\s+"([^"]+)"/i.exec(cmd)
     return (m?.[1] ?? '').toUpperCase()
+  }
+
+  const appendTerminalTexts = (texts: string[]) => {
+    if (texts.length === 0) {
+      return
+    }
+    setTerminalHistory((prev) => {
+      const out = [...prev.slice(-199)]
+      for (const text of texts) {
+        terminalLineIdRef.current += 1
+        out.push(c64TextRow(terminalLineIdRef.current, text))
+      }
+      return out
+    })
+  }
+
+  /** Blank row after READY. in the log (separates command blocks). */
+  const appendReadyWithGap = () => {
+    appendTerminalTexts(['READY.', ''])
+  }
+
+  const appendTerminalDiskCatalogEmbed = () => {
+    setTerminalHistory((prev) => {
+      const out = [...prev.slice(-199)]
+      terminalLineIdRef.current += 1
+      out.push({ id: terminalLineIdRef.current, kind: 'disk-catalog' })
+      return out
+    })
+  }
+
+  /**
+   * LIST: BASIC program lines in the log if any; else LIST + clickable disk catalog embed + READY.
+   */
+  const handleDirectListCommand = () => {
+    if (basicProgramRef.current.size > 0) {
+      appendTerminalTexts([
+        'LIST',
+        ...listProgram(basicProgramRef.current),
+        'READY.',
+        '',
+      ])
+      return
+    }
+    appendTerminalTexts(['LIST'])
+    appendTerminalDiskCatalogEmbed()
+    appendTerminalTexts(['READY.', ''])
+    if (diskCatalogReady) {
+      setDiskCatalogReady(false)
+    }
+  }
+
+  const startBasicRun = (entryLine?: number) => {
+    const ac = new AbortController()
+    basicAbortRef.current = ac
+    basicLivePrintRowIdRef.current = null
+    setBasicRunning(true)
+    void (async () => {
+      let printBuf = ''
+
+      const pumpPrintToTerminal = () => {
+        basicPrintRafRef.current = null
+        if (printBuf.length === 0) return
+        const text = printBuf
+        const liveId = basicLivePrintRowIdRef.current
+        if (liveId === null) {
+          terminalLineIdRef.current += 1
+          const id = terminalLineIdRef.current
+          basicLivePrintRowIdRef.current = id
+          setTerminalHistory((prev) => [...prev.slice(-199), c64TextRow(id, text)])
+        } else {
+          setTerminalHistory((prev) =>
+            prev.map((row) =>
+              row.id === liveId && row.kind === 'text'
+                ? c64TextRow(row.id, text)
+                : row,
+            ),
+          )
+        }
+      }
+
+      const schedulePump = () => {
+        if (basicPrintRafRef.current !== null) return
+        basicPrintRafRef.current = requestAnimationFrame(() => {
+          pumpPrintToTerminal()
+        })
+      }
+
+      const cancelPumpRaf = () => {
+        if (basicPrintRafRef.current !== null) {
+          cancelAnimationFrame(basicPrintRafRef.current)
+          basicPrintRafRef.current = null
+        }
+      }
+
+      const flushPrintSync = () => {
+        cancelPumpRaf()
+        pumpPrintToTerminal()
+      }
+
+      ac.signal.addEventListener('abort', flushPrintSync)
+
+      const onOutput = (op: BasicOutputOp) => {
+        if (op.op === 'append') {
+          printBuf += op.text
+          schedulePump()
+        } else if (op.op === 'newline') {
+          flushPrintSync()
+          printBuf = ''
+          basicLivePrintRowIdRef.current = null
+        } else if (op.op === 'lines') {
+          flushPrintSync()
+          printBuf = ''
+          basicLivePrintRowIdRef.current = null
+          appendTerminalTexts(op.texts)
+        }
+      }
+      try {
+        await runBasicProgram(basicProgramRef.current, {
+          entryLine,
+          signal: ac.signal,
+          onOutput,
+        })
+      } finally {
+        ac.signal.removeEventListener('abort', flushPrintSync)
+        flushPrintSync()
+        printBuf = ''
+        basicLivePrintRowIdRef.current = null
+        if (basicAbortRef.current === ac) {
+          basicAbortRef.current = null
+        }
+        setBasicRunning(false)
+        appendReadyWithGap()
+        window.requestAnimationFrame(() => {
+          focusC64TerminalInput(terminalInputRef)
+        })
+      }
+    })()
   }
 
   const handleDirectoryProgramKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
@@ -388,6 +758,7 @@ export default function C64AuthenticHomeScreen({
     source: 'manual' | 'click',
     searchLabel: string,
   ) => {
+    setDiskCatalogReady(false)
     clearTerminalLoadTimeoutsOnly()
     terminalLoadRunIdRef.current += 1
     const runId = terminalLoadRunIdRef.current
@@ -400,10 +771,10 @@ export default function C64AuthenticHomeScreen({
       window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
     const appendRows = (texts: string[]) => {
-      const rows: { id: number; text: string }[] = []
+      const rows: C64TerminalHistoryRow[] = []
       for (const text of texts) {
         terminalLineIdRef.current += 1
-        rows.push({ id: terminalLineIdRef.current, text })
+        rows.push(c64TextRow(terminalLineIdRef.current, text))
       }
       setTerminalHistory((prev) => [...prev.slice(-199), ...rows])
     }
@@ -414,6 +785,7 @@ export default function C64AuthenticHomeScreen({
         `SEARCHING FOR ${searchLabel}`,
         'LOADING',
         'READY.',
+        '',
         ...(source === 'click' ? (['RUN'] as const) : []),
       ]
       appendRows([...texts])
@@ -455,7 +827,7 @@ export default function C64AuthenticHomeScreen({
       const loadingId = terminalLineIdRef.current
       setTerminalHistory((prev) => [
         ...prev.slice(-199),
-        { id: loadingId, text: 'LOADING' },
+        c64TextRow(loadingId, 'LOADING'),
       ])
       setTerminalLoadingLineId(loadingId)
 
@@ -473,9 +845,12 @@ export default function C64AuthenticHomeScreen({
           setTerminalLoadingLineId(null)
           terminalLineIdRef.current += 1
           const readyId = terminalLineIdRef.current
+          terminalLineIdRef.current += 1
+          const readyGapId = terminalLineIdRef.current
           setTerminalHistory((prev) => [
             ...prev.slice(-199),
-            { id: readyId, text: 'READY.' },
+            c64TextRow(readyId, 'READY.'),
+            c64TextRow(readyGapId, ''),
           ])
           setTerminalSequenceBusy(false)
           if (source === 'click') {
@@ -487,7 +862,7 @@ export default function C64AuthenticHomeScreen({
               const runRowId = terminalLineIdRef.current
               setTerminalHistory((prev) => [
                 ...prev.slice(-199),
-                { id: runRowId, text: 'RUN' },
+                c64TextRow(runRowId, 'RUN'),
               ])
               handlersRef.current[action]()
             }, TERMINAL_AUTO_RUN_PAUSE_MS)
@@ -498,6 +873,152 @@ export default function C64AuthenticHomeScreen({
       }
       runSpinFrame(0)
     }, tLoading)
+  }
+
+  type DiskCatalogSequenceOpts = {
+    /** Log LOAD"$",8 before blank (closing a drawer — full disk reload). */
+    logSyntheticLoadLine?: boolean
+    /** After READY.: append LIST + clickable embed + READY. instead of $-catalog readiness only. */
+    endWithListEmbed?: boolean
+    /** Called after sequence fully finishes (reduced or animated). */
+    onComplete?: () => void
+  }
+
+  /** LOAD "$",8: same cadence as a PRG load; optional drawer replay then auto-LIST + embed. */
+  const startTerminalDiskCatalogSequence = (opts?: DiskCatalogSequenceOpts) => {
+    setDiskCatalogReady(false)
+    clearTerminalLoadTimeoutsOnly()
+    terminalLoadRunIdRef.current += 1
+    const runId = terminalLoadRunIdRef.current
+    setTerminalPendingRun(null)
+    setTerminalLoadingLineId(null)
+    setTerminalLoadingGlyph(null)
+
+    if (opts?.logSyntheticLoadLine) {
+      appendTerminalTexts([DISK_SEQUENCE_LINES[1]])
+    }
+
+    const finishListEmbed = () => {
+      appendTerminalTexts(['LIST'])
+      appendTerminalDiskCatalogEmbed()
+      appendTerminalTexts(['READY.', ''])
+      opts?.onComplete?.()
+    }
+
+    const finishCatalogReadyOnly = () => {
+      setDiskCatalogReady(true)
+      opts?.onComplete?.()
+    }
+
+    const reduced =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    const appendRows = (texts: string[]) => {
+      const rows: C64TerminalHistoryRow[] = []
+      for (const text of texts) {
+        terminalLineIdRef.current += 1
+        rows.push(c64TextRow(terminalLineIdRef.current, text))
+      }
+      setTerminalHistory((prev) => [...prev.slice(-199), ...rows])
+    }
+
+    if (reduced) {
+      appendRows(['', 'SEARCHING FOR $', 'LOADING', 'READY.', ''])
+      setTerminalSequenceBusy(false)
+      if (opts?.endWithListEmbed) {
+        finishListEmbed()
+      } else {
+        finishCatalogReadyOnly()
+      }
+      return
+    }
+
+    setTerminalSequenceBusy(true)
+
+    const schedule = (fn: () => void, ms: number) => {
+      const tid = window.setTimeout(() => {
+        if (terminalLoadRunIdRef.current !== runId) {
+          return
+        }
+        fn()
+      }, ms) as unknown as number
+      terminalLoadTimeoutsRef.current.push(tid)
+    }
+
+    const tBlank = TERMINAL_LOAD_BLANK_PAUSE_MS
+    const tSearch = tBlank + TERMINAL_LOAD_AFTER_BLANK_MS
+    const tLoading = tSearch + TERMINAL_LOAD_AFTER_SEARCHING_MS
+
+    schedule(() => {
+      appendRows([''])
+    }, tBlank)
+
+    schedule(() => {
+      appendRows(['SEARCHING FOR $'])
+    }, tSearch)
+
+    schedule(() => {
+      terminalLineIdRef.current += 1
+      const loadingId = terminalLineIdRef.current
+      setTerminalHistory((prev) => [
+        ...prev.slice(-199),
+        c64TextRow(loadingId, 'LOADING'),
+      ])
+      setTerminalLoadingLineId(loadingId)
+
+      const runSpinFrame = (frame: number) => {
+        if (terminalLoadRunIdRef.current !== runId) {
+          return
+        }
+        setTerminalLoadingGlyph(
+          TERMINAL_LOAD_SPIN_CHARS[frame % TERMINAL_LOAD_SPIN_CHARS.length],
+        )
+        if (frame + 1 < TERMINAL_LOAD_SPIN_FRAME_COUNT) {
+          schedule(() => runSpinFrame(frame + 1), TERMINAL_LOAD_SPIN_FRAME_MS)
+        } else {
+          setTerminalLoadingGlyph(null)
+          setTerminalLoadingLineId(null)
+          terminalLineIdRef.current += 1
+          const readyId = terminalLineIdRef.current
+          terminalLineIdRef.current += 1
+          const readyGapId = terminalLineIdRef.current
+          setTerminalHistory((prev) => [
+            ...prev.slice(-199),
+            c64TextRow(readyId, 'READY.'),
+            c64TextRow(readyGapId, ''),
+          ])
+          setTerminalSequenceBusy(false)
+          if (opts?.endWithListEmbed) {
+            finishListEmbed()
+          } else {
+            finishCatalogReadyOnly()
+          }
+        }
+      }
+      runSpinFrame(0)
+    }, tLoading)
+  }
+
+  playDiskListReplayRef.current = () => {
+    if (!bootComplete) {
+      return
+    }
+    if (terminalTypewriterTimeoutRef.current !== undefined) {
+      window.clearTimeout(terminalTypewriterTimeoutRef.current)
+    }
+    terminalTypewriterRunIdRef.current += 1
+    setTerminalLine('')
+    setTerminalAutoTyping(false)
+    startTerminalDiskCatalogSequence({
+      logSyntheticLoadLine: true,
+      endWithListEmbed: true,
+      onComplete: () => {
+        window.requestAnimationFrame(() => {
+          focusC64TerminalInput(terminalInputRef, { force: true })
+        })
+      },
+    })
   }
 
   const playLoadCommandFromList = (action: keyof C64HomeCommandHandlers) => {
@@ -516,7 +1037,7 @@ export default function C64AuthenticHomeScreen({
     if (reduced) {
       terminalLineIdRef.current += 1
       const id = terminalLineIdRef.current
-      setTerminalHistory((prev) => [...prev.slice(-199), { id, text: full }])
+      setTerminalHistory((prev) => [...prev.slice(-199), c64TextRow(id, full)])
       setTerminalLine('')
       startTerminalLoadSequence(
         action,
@@ -557,7 +1078,7 @@ export default function C64AuthenticHomeScreen({
           }
           terminalLineIdRef.current += 1
           const id = terminalLineIdRef.current
-          setTerminalHistory((prev) => [...prev.slice(-199), { id, text: full }])
+          setTerminalHistory((prev) => [...prev.slice(-199), c64TextRow(id, full)])
           setTerminalLine('')
           setTerminalAutoTyping(false)
           startTerminalLoadSequence(
@@ -712,6 +1233,239 @@ export default function C64AuthenticHomeScreen({
     }
   }, [])
 
+  terminalSubmitRef.current = (nextRaw: string) => {
+    const next = nextRaw.replace(/\r/g, '').trim()
+    if (next.length === 0) {
+      setTerminalLine('')
+      window.requestAnimationFrame(() => {
+        focusC64TerminalInput(terminalInputRef)
+      })
+      return
+    }
+
+    if (terminalPendingRun) {
+      if (/^RUN$/i.test(next)) {
+        terminalLineIdRef.current += 1
+        const runLineId = terminalLineIdRef.current
+        const { action: pendingAction } = terminalPendingRun
+        setTerminalPendingRun(null)
+        setTerminalHistory((prev) => [
+          ...prev.slice(-199),
+          c64TextRow(runLineId, 'RUN'),
+        ])
+        handlers[pendingAction]()
+      } else {
+        const loadAction = getTypedLoadAction(next)
+        if (loadAction !== null) {
+          terminalLineIdRef.current += 1
+          const lineId = terminalLineIdRef.current
+          setTerminalPendingRun(null)
+          setTerminalHistory((prev) => [
+            ...prev.slice(-199),
+            c64TextRow(lineId, next),
+          ])
+          setTerminalLine('')
+          startTerminalLoadSequence(
+            loadAction,
+            'manual',
+            searchLabelFromLoadCommand(
+              LOAD_COMMAND_BY_ACTION[loadAction],
+            ),
+          )
+          window.requestAnimationFrame(() => {
+            focusC64TerminalInput(terminalInputRef)
+          })
+          return
+        }
+        if (isLoadDiskCatalogCommand(next)) {
+          setTerminalPendingRun(null)
+          terminalLineIdRef.current += 1
+          const catLineId = terminalLineIdRef.current
+          setTerminalHistory((prev) => [
+            ...prev.slice(-199),
+            c64TextRow(catLineId, normalizeInputLine(next).toUpperCase()),
+          ])
+          setTerminalLine('')
+          startTerminalDiskCatalogSequence()
+          window.requestAnimationFrame(() => {
+            focusC64TerminalInput(terminalInputRef)
+          })
+          return
+        }
+        const plPending = tryParseProgramLine(next)
+        if (plPending !== null) {
+          setTerminalPendingRun(null)
+          storeProgramLine(
+            basicProgramRef.current,
+            plPending.lineNum,
+            plPending.rest,
+          )
+          setDiskCatalogReady(false)
+          const echo = formatProgramLineEcho(
+            plPending.lineNum,
+            plPending.rest,
+          )
+          appendTerminalTexts([echo])
+        } else if (isDirectList(next)) {
+          setTerminalPendingRun(null)
+          handleDirectListCommand()
+        } else if (isDirectNew(next)) {
+          setTerminalPendingRun(null)
+          basicProgramRef.current = createBasicProgram()
+          resetDirectEvalContext()
+          setDiskCatalogReady(false)
+          appendTerminalTexts(['NEW', 'READY.', ''])
+        } else {
+          const gotoTargetPending = tryDirectGoto(next)
+          const printDirectPending = tryDirectPrint(next)
+          if (gotoTargetPending !== null) {
+            setTerminalPendingRun(null)
+            appendTerminalTexts([
+              normalizeInputLine(next).toUpperCase(),
+            ])
+            setTerminalLine('')
+            startBasicRun(gotoTargetPending)
+            window.requestAnimationFrame(() => {
+              focusC64TerminalInput(terminalInputRef)
+            })
+            return
+          }
+          if (printDirectPending.ok) {
+            setTerminalPendingRun(null)
+            appendTerminalTexts([
+              normalizeInputLine(next).toUpperCase(),
+            ])
+            applyBasicOutputOps(
+              printDirectPending.ops,
+              appendTerminalTexts,
+            )
+            appendReadyWithGap()
+          } else {
+            terminalLineIdRef.current += 1
+            const badLineId = terminalLineIdRef.current
+            terminalLineIdRef.current += 1
+            const errId = terminalLineIdRef.current
+            setTerminalHistory((prev) => [
+              ...prev.slice(-199),
+              c64TextRow(badLineId, next),
+              c64TextRow(errId, '?SYNTAX ERROR'),
+            ])
+          }
+        }
+      }
+      setTerminalLine('')
+      window.requestAnimationFrame(() => {
+        focusC64TerminalInput(terminalInputRef)
+      })
+      return
+    }
+
+    if (isLoadDiskCatalogCommand(next)) {
+      terminalLineIdRef.current += 1
+      const catLineId = terminalLineIdRef.current
+      setTerminalHistory((prev) => [
+        ...prev.slice(-199),
+        c64TextRow(catLineId, normalizeInputLine(next).toUpperCase()),
+      ])
+      setTerminalLine('')
+      startTerminalDiskCatalogSequence()
+      window.requestAnimationFrame(() => {
+        focusC64TerminalInput(terminalInputRef)
+      })
+      return
+    }
+
+    const pl = tryParseProgramLine(next)
+    if (pl !== null) {
+      storeProgramLine(basicProgramRef.current, pl.lineNum, pl.rest)
+      setDiskCatalogReady(false)
+      const echo = formatProgramLineEcho(pl.lineNum, pl.rest)
+      appendTerminalTexts([echo])
+      setTerminalLine('')
+      window.requestAnimationFrame(() => {
+        focusC64TerminalInput(terminalInputRef)
+      })
+      return
+    }
+
+    if (isDirectList(next)) {
+      handleDirectListCommand()
+      setTerminalLine('')
+      window.requestAnimationFrame(() => {
+        focusC64TerminalInput(terminalInputRef)
+      })
+      return
+    }
+
+    if (isDirectNew(next)) {
+      basicProgramRef.current = createBasicProgram()
+      resetDirectEvalContext()
+      setDiskCatalogReady(false)
+      appendTerminalTexts(['NEW', 'READY.', ''])
+      setTerminalLine('')
+      window.requestAnimationFrame(() => {
+        focusC64TerminalInput(terminalInputRef)
+      })
+      return
+    }
+
+    if (isDirectRun(next)) {
+      appendTerminalTexts(['RUN'])
+      setTerminalLine('')
+      startBasicRun()
+      return
+    }
+
+    const gotoTarget = tryDirectGoto(next)
+    if (gotoTarget !== null) {
+      appendTerminalTexts([normalizeInputLine(next).toUpperCase()])
+      setTerminalLine('')
+      startBasicRun(gotoTarget)
+      return
+    }
+
+    const printDirect = tryDirectPrint(next)
+    if (printDirect.ok) {
+      appendTerminalTexts([normalizeInputLine(next).toUpperCase()])
+      applyBasicOutputOps(printDirect.ops, appendTerminalTexts)
+      appendReadyWithGap()
+      setTerminalLine('')
+      window.requestAnimationFrame(() => {
+        focusC64TerminalInput(terminalInputRef)
+      })
+      return
+    }
+
+    const action = getTypedLoadAction(next)
+    terminalLineIdRef.current += 1
+    const id = terminalLineIdRef.current
+    const rows: C64TerminalHistoryRow[] = [c64TextRow(id, next)]
+    if (action === null) {
+      terminalLineIdRef.current += 1
+      rows.push(c64TextRow(terminalLineIdRef.current, '?SYNTAX ERROR'))
+      setTerminalHistory((prev) => [
+        ...prev.slice(-199),
+        ...rows,
+      ])
+    } else {
+      setTerminalHistory((prev) => [
+        ...prev.slice(-199),
+        ...rows,
+      ])
+      startTerminalLoadSequence(
+        action,
+        'manual',
+        searchLabelFromLoadCommand(
+          LOAD_COMMAND_BY_ACTION[action],
+        ),
+      )
+    }
+    setTerminalLine('')
+    window.requestAnimationFrame(() => {
+      focusC64TerminalInput(terminalInputRef)
+    })
+  }
+
   const showDiskBlock =
     diskCompletedLines.length > 0 ||
     diskTyping !== null ||
@@ -762,13 +1516,15 @@ export default function C64AuthenticHomeScreen({
           {bootComplete && (
             <div className="c64-dir-listing mt-6 sm:mt-8 text-left shrink-0 min-w-0 max-w-full">
               <p className="sr-only" id="c64-disk-directory-hint">
-                Disk directory. Each program opens a section; close the panel to return here. The
-                listing stays pinned while the command log scrolls. Use Tab to reach a program, arrow
-                keys or Home and End to move in the list, Enter to run.
+                Disk directory: use the clickable program rows here, or type LOAD &quot;NAME&quot;,8,1
+                and RUN. LIST with no BASIC program inserts the same clickable directory in the command
+                log below. After LOAD &quot;$&quot;,8, LIST does that and clears $-catalog readiness.
+                Close a site panel to replay LIST in the log. Tab into a list; arrow keys or Home and End;
+                Enter to run.
               </p>
 
               <div className="c64-dir-listing-sticky">
-                <div className="c64-dir-header text-xs sm:text-base md:text-lg leading-tight tracking-wide px-2 py-1.5 rounded-sm">
+                <div className="c64-dir-header text-xs sm:text-base md:text-lg leading-tight tracking-wide py-1.5 rounded-sm">
                   {DISK_VOLUME_LINE}
                 </div>
 
@@ -819,32 +1575,78 @@ export default function C64AuthenticHomeScreen({
                 }}
               >
                 <div className="sr-only" aria-live="polite">
-                  {terminalHistory.length > 0
-                    ? `Printed: ${terminalHistory[terminalHistory.length - 1]?.text ?? ''}`
-                    : ''}
+                  {(() => {
+                    const last = terminalHistory[terminalHistory.length - 1]
+                    if (last === undefined) return ''
+                    if (last.kind === 'text') return `Terminal: ${last.text}`
+                    return 'Terminal: disk directory from LIST'
+                  })()}
                 </div>
-                {terminalHistory.map((row) => (
-                  <div key={row.id} className="whitespace-pre-wrap break-words m-0">
-                    {row.text}
-                    {row.id === terminalLoadingLineId &&
-                    terminalLoadingGlyph !== null ? (
-                      <span className="c64-disk-spin-char" aria-hidden>
-                        {terminalLoadingGlyph}
-                      </span>
-                    ) : null}
-                  </div>
-                ))}
+                {terminalHistory.map((row) =>
+                  row.kind === 'disk-catalog' ? (
+                    <div key={row.id} className="m-0 w-full max-w-full">
+                      <TerminalDiskCatalogEmbed
+                        blockId={row.id}
+                        onPlayLoad={playLoadCommandFromList}
+                        onProgramKeyDown={handleDirectoryProgramKeyDown}
+                      />
+                    </div>
+                  ) : (
+                    <div
+                      key={row.id}
+                      className={
+                        row.text === ''
+                          ? 'm-0 min-h-[1.2em]'
+                          : 'whitespace-pre-wrap break-words m-0'
+                      }
+                    >
+                      {row.text}
+                      {row.id === terminalLoadingLineId &&
+                      terminalLoadingGlyph !== null ? (
+                        <span className="c64-disk-spin-char" aria-hidden>
+                          {terminalLoadingGlyph}
+                        </span>
+                      ) : null}
+                    </div>
+                  ),
+                )}
                 <div className="c64-terminal-prompt relative mt-0 block w-full max-w-full min-h-[1.35em]">
                   <label htmlFor="c64-terminal-input" className="sr-only">
-                    Type LOAD &quot;NAME&quot;,8,1 then Enter; when the computer prints READY., type RUN and Enter to open. Or choose a program from the disk list — RUN is entered for you.
+                    Disk: use the directory above or type LOAD &quot;NAME&quot;,8,1 then Enter; when the computer prints READY., type RUN and Enter to open, or pick a program from the list (RUN is typed for you). With no BASIC program, LIST inserts a clickable disk catalog into this log. LOAD &quot;$&quot;,8 then LIST does the same and clears $-catalog readiness. Escape clears that readiness. BASIC: numbered lines store without READY after each line; LIST lists the program if any lines exist. PRINT supports CHR$(), RND(), INT, SIN, COS, comparisons (equals and less-than / greater-than), caret for power, one-letter variables A through Z with optional LET, IF condition THEN line number, FOR and NEXT (each on its own line; nested loops allowed), semicolons to stay on the same line, commas for spacing, and colons to put more than one statement on a line. Logical screen rows follow PRINT newlines; the view may wrap long lines on narrow screens. Output wraps in the browser like a modern terminal, not a fixed 40-column C64 screen. NEW, GOTO, RUN; on touch devices a Stop control appears while a program runs; on desktop use Escape when no panel is open.
                   </label>
+                  {basicRunning && basicStopTouchUi ? (
+                    <button
+                      type="button"
+                      className="relative z-[2] mb-2 inline-flex min-h-11 min-w-[5.5rem] touch-manipulation cursor-pointer items-center justify-center rounded-sm border-2 border-[var(--c64-accent)] bg-[var(--c64-border-bg)] px-3 py-2 text-center font-inherit text-sm text-[var(--c64-crt-ink)] shadow-sm active:opacity-90"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        basicAbortRef.current?.abort()
+                      }}
+                      onPointerDown={(e) => e.stopPropagation()}
+                      aria-label="Stop BASIC program"
+                    >
+                      [STOP]
+                    </button>
+                  ) : null}
                   <span className="whitespace-pre-wrap break-words align-bottom text-[var(--c64-crt-ink)]">
-                    {terminalLine}
+                    {terminalLine.slice(0, terminalPromptCaretPos)}
                   </span>
-                  <span
-                    className="c64-disk-type-cursor c64-authentic-cursor align-bottom"
-                    aria-hidden
-                  />
+                  {terminalPromptCaretPos < terminalLine.length ? (
+                    <span
+                      className="c64-terminal-cursor-inverse align-bottom"
+                      aria-hidden
+                    >
+                      {terminalLine.charAt(terminalPromptCaretPos)}
+                    </span>
+                  ) : (
+                    <span
+                      className="c64-disk-type-cursor c64-authentic-cursor align-bottom"
+                      aria-hidden
+                    />
+                  )}
+                  <span className="whitespace-pre-wrap break-words align-bottom text-[var(--c64-crt-ink)]">
+                    {terminalLine.slice(terminalPromptCaretPos + 1)}
+                  </span>
                   <input
                     id="c64-terminal-input"
                     ref={terminalInputRef}
@@ -855,17 +1657,31 @@ export default function C64AuthenticHomeScreen({
                     autoCapitalize="off"
                     spellCheck={false}
                     value={terminalLine}
-                    readOnly={terminalAutoTyping || terminalSequenceBusy}
-                    aria-busy={terminalAutoTyping || terminalSequenceBusy}
+                    readOnly={terminalAutoTyping || terminalSequenceBusy || basicRunning}
+                    aria-busy={terminalAutoTyping || terminalSequenceBusy || basicRunning}
                     onChange={(e) => {
-                      if (terminalAutoTyping || terminalSequenceBusy) {
+                      if (terminalAutoTyping || terminalSequenceBusy || basicRunning) {
                         return
                       }
-                      setTerminalLine(e.target.value)
+                      const el = e.currentTarget
+                      setTerminalLine(el.value)
+                      syncTerminalCaretFromInput(el)
+                    }}
+                    onSelect={(e) => {
+                      syncTerminalCaretFromInput(e.currentTarget)
+                    }}
+                    onClick={(e) => {
+                      syncTerminalCaretFromInput(e.currentTarget)
                     }}
                     onKeyDown={(e) => {
                       if (terminalAutoTyping) {
                         e.preventDefault()
+                        return
+                      }
+                      if (basicRunning) {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                        }
                         return
                       }
                       if (terminalSequenceBusy) {
@@ -876,100 +1692,43 @@ export default function C64AuthenticHomeScreen({
                       }
                       if (e.key === 'Enter') {
                         e.preventDefault()
-                        const next = terminalLine.replace(/\r/g, '').trim()
-                        if (next.length === 0) {
-                          setTerminalLine('')
-                          window.requestAnimationFrame(() => {
-                            focusC64TerminalInput(terminalInputRef)
-                          })
+                        terminalSubmitRef.current(
+                          terminalLine.replace(/\r/g, '').trim(),
+                        )
+                        return
+                      }
+                    }}
+                    onPaste={(e: ClipboardEvent<HTMLInputElement>) => {
+                      if (
+                        terminalAutoTyping ||
+                        terminalSequenceBusy ||
+                        basicRunning
+                      ) {
+                        return
+                      }
+                      const clip = e.clipboardData?.getData('text/plain') ?? ''
+                      if (!/[\r\n\u2028\u2029]/.test(clip)) {
+                        return
+                      }
+                      e.preventDefault()
+                      const lines = clip
+                        .split(/\r\n|\r|\n|\u2028|\u2029/)
+                        .map((line) => line.replace(/\r/g, '').trim())
+                        .filter(
+                          (line) => line.length > 0 && !/^```/.test(line),
+                        )
+                      setTerminalLine('')
+                      setTerminalCaretPos(0)
+                      const runLine = (i: number) => {
+                        if (i >= lines.length) {
                           return
                         }
-
-                        if (terminalPendingRun) {
-                          if (/^RUN$/i.test(next)) {
-                            terminalLineIdRef.current += 1
-                            const runLineId = terminalLineIdRef.current
-                            const { action: pendingAction } = terminalPendingRun
-                            setTerminalPendingRun(null)
-                            setTerminalHistory((prev) => [
-                              ...prev.slice(-199),
-                              { id: runLineId, text: 'RUN' },
-                            ])
-                            handlers[pendingAction]()
-                          } else {
-                            const loadAction = getTypedLoadAction(next)
-                            if (loadAction !== null) {
-                              terminalLineIdRef.current += 1
-                              const lineId = terminalLineIdRef.current
-                              setTerminalPendingRun(null)
-                              setTerminalHistory((prev) => [
-                                ...prev.slice(-199),
-                                { id: lineId, text: next },
-                              ])
-                              setTerminalLine('')
-                              startTerminalLoadSequence(
-                                loadAction,
-                                'manual',
-                                searchLabelFromLoadCommand(
-                                  LOAD_COMMAND_BY_ACTION[loadAction],
-                                ),
-                              )
-                              window.requestAnimationFrame(() => {
-                                focusC64TerminalInput(terminalInputRef)
-                              })
-                              return
-                            }
-                            terminalLineIdRef.current += 1
-                            const badLineId = terminalLineIdRef.current
-                            terminalLineIdRef.current += 1
-                            const errId = terminalLineIdRef.current
-                            setTerminalHistory((prev) => [
-                              ...prev.slice(-199),
-                              { id: badLineId, text: next },
-                              { id: errId, text: '?SYNTAX ERROR' },
-                            ])
-                          }
-                          setTerminalLine('')
-                          window.requestAnimationFrame(() => {
-                            focusC64TerminalInput(terminalInputRef)
-                          })
-                          return
-                        }
-
-                        const action = getTypedLoadAction(next)
-                        terminalLineIdRef.current += 1
-                        const id = terminalLineIdRef.current
-                        const rows: { id: number; text: string }[] = [
-                          { id, text: next },
-                        ]
-                        if (action === null) {
-                          terminalLineIdRef.current += 1
-                          rows.push({
-                            id: terminalLineIdRef.current,
-                            text: '?SYNTAX ERROR',
-                          })
-                          setTerminalHistory((prev) => [
-                            ...prev.slice(-199),
-                            ...rows,
-                          ])
-                        } else {
-                          setTerminalHistory((prev) => [
-                            ...prev.slice(-199),
-                            ...rows,
-                          ])
-                          startTerminalLoadSequence(
-                            action,
-                            'manual',
-                            searchLabelFromLoadCommand(
-                              LOAD_COMMAND_BY_ACTION[action],
-                            ),
-                          )
-                        }
-                        setTerminalLine('')
                         window.requestAnimationFrame(() => {
-                          focusC64TerminalInput(terminalInputRef)
+                          terminalSubmitRef.current(lines[i]!)
+                          runLine(i + 1)
                         })
                       }
+                      runLine(0)
                     }}
                     className="c64-terminal-input absolute inset-0 z-[1] h-full min-h-0 w-full cursor-text rounded-none border-0 bg-transparent p-0 text-transparent caret-transparent shadow-none ring-0 outline-none focus:outline-none focus-visible:outline-none focus:ring-0 selection:bg-transparent"
                   />

--- a/src/app/components/C64AuthenticHomeScreen.tsx
+++ b/src/app/components/C64AuthenticHomeScreen.tsx
@@ -338,6 +338,11 @@ export default function C64AuthenticHomeScreen({
   /** Show on-screen [STOP] only on phones / coarse-pointer tablets (desktop uses Escape). */
   const [basicStopTouchUi, setBasicStopTouchUi] = useState(false)
   const basicProgramRef = useRef(createBasicProgram())
+  /** C64-style: directory load overwrites BASIC program RAM (no NEW line). */
+  const wipeBasicProgramMemory = () => {
+    basicProgramRef.current = createBasicProgram()
+    resetDirectEvalContext()
+  }
   /** After manual LOAD "$",8 finishes, LIST prints the disk catalog in the terminal log. */
   const [diskCatalogReady, setDiskCatalogReady] = useState(false)
   const basicAbortRef = useRef<AbortController | null>(null)
@@ -1279,6 +1284,7 @@ export default function C64AuthenticHomeScreen({
         }
         if (isLoadDiskCatalogCommand(next)) {
           setTerminalPendingRun(null)
+          wipeBasicProgramMemory()
           terminalLineIdRef.current += 1
           const catLineId = terminalLineIdRef.current
           setTerminalHistory((prev) => [
@@ -1361,6 +1367,7 @@ export default function C64AuthenticHomeScreen({
     }
 
     if (isLoadDiskCatalogCommand(next)) {
+      wipeBasicProgramMemory()
       terminalLineIdRef.current += 1
       const catLineId = terminalLineIdRef.current
       setTerminalHistory((prev) => [

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -795,17 +795,16 @@ body > div[style*="position: fixed"] * {
   max-width: 100%;
 }
 
-/* Stays on-screen while terminal history scrolls (sticky within .c64-authentic-screen-scroll). */
+/* Disk chrome scrolls with the CRT log (C64-style: re-LIST after closing a PRG). */
 #c64-site-root .c64-authentic-screen .c64-dir-listing-sticky {
-  position: sticky;
-  top: 0;
-  z-index: 2;
+  position: static;
   align-self: stretch;
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
   background: var(--c64-screen-bg, #352879);
-  padding: 0.55rem 0.85rem 0.85rem;
+  /* No horizontal padding — listing aligns with terminal / boot text */
+  padding: 0.55rem 0 0.85rem;
   margin-bottom: 0.15rem;
 }
 
@@ -848,7 +847,7 @@ body > div[style*="position: fixed"] * {
   width: 100%;
   min-width: 0;
   min-height: 0;
-  padding: 0 0.25rem;
+  padding: 0;
   margin: 0;
   box-sizing: border-box;
   line-height: 1.25;
@@ -1176,8 +1175,29 @@ body > div[style*="position: fixed"] * {
   animation: c64-cursor-blink 1s steps(1, end) infinite;
 }
 
+/* Prompt: inverse-video cell on the character under the caret (C64-style). */
+#c64-site-root .c64-authentic-screen .c64-terminal .c64-terminal-cursor-inverse {
+  display: inline-block;
+  vertical-align: text-bottom;
+  min-width: 1ch;
+  text-align: center;
+  background: var(--c64-crt-ink);
+  color: var(--c64-screen-bg);
+  animation: none;
+  opacity: 1;
+}
+
+#c64-site-root .c64-authentic-screen .c64-terminal:focus-within .c64-terminal-cursor-inverse {
+  animation: c64-cursor-blink 1s steps(1, end) infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   #c64-site-root .c64-authentic-screen .c64-disk-type-cursor {
+    animation: none !important;
+    opacity: 1;
+  }
+
+  #c64-site-root .c64-authentic-screen .c64-terminal-cursor-inverse {
     animation: none !important;
     opacity: 1;
   }

--- a/src/lib/c64-basic.test.ts
+++ b/src/lib/c64-basic.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest'
+
+import type { BasicOutputOp } from './c64-basic'
+import {
+  BASIC_MAX_STEPS,
+  createBasicProgram,
+  evalNumericExpression,
+  formatProgramLineEcho,
+  listProgram,
+  runBasicProgram,
+  splitStatements,
+  storeProgramLine,
+  tryDirectGoto,
+  resetDirectEvalContext,
+  tryDirectPrint,
+  tryParseProgramLine,
+  petsciiScreenToChar,
+  c64ByteFromFloat,
+} from './c64-basic'
+
+async function runCollecting(
+  program: ReturnType<typeof createBasicProgram>,
+  opts: Omit<Parameters<typeof runBasicProgram>[1], 'onOutput'>,
+): Promise<{ st: Awaited<ReturnType<typeof runBasicProgram>>; lines: string[] }> {
+  const lines: string[] = []
+  let buf = ''
+  const st = await runBasicProgram(program, {
+    ...opts,
+    onOutput: (op) => {
+      if (op.op === 'append') buf += op.text
+      else if (op.op === 'newline') {
+        lines.push(buf)
+        buf = ''
+      } else if (op.op === 'lines') {
+        if (buf.length > 0) {
+          lines.push(buf)
+          buf = ''
+        }
+        lines.push(...op.texts)
+      }
+    },
+  })
+  if (buf.length > 0) lines.push(buf)
+  return { st, lines }
+}
+
+function opsToRows(ops: BasicOutputOp[]): string[] {
+  const lines: string[] = []
+  let buf = ''
+  for (const op of ops) {
+    if (op.op === 'append') buf += op.text
+    else if (op.op === 'newline') {
+      lines.push(buf)
+      buf = ''
+    } else if (op.op === 'lines') {
+      if (buf.length > 0) {
+        lines.push(buf)
+        buf = ''
+      }
+      lines.push(...op.texts)
+    }
+  }
+  if (buf.length > 0) lines.push(buf)
+  return lines
+}
+
+describe('c64-basic', () => {
+  it('stores, canonicalizes, and deletes program lines', () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PrInT "hi"')
+    expect(p.get(10)).toBe('PRINT "HI"')
+    storeProgramLine(p, 10, '   ')
+    expect(p.has(10)).toBe(false)
+  })
+
+  it('lists lines in numeric order', () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 20, 'PRINT 1')
+    storeProgramLine(p, 10, 'PRINT 2')
+    expect(listProgram(p)).toEqual(['10 PRINT 2', '20 PRINT 1'])
+  })
+
+  it('formatProgramLineEcho matches stored form', () => {
+    expect(formatProgramLineEcho(10, 'print 1+1')).toBe('10 PRINT 1+1')
+    expect(formatProgramLineEcho(5, '')).toBe('5')
+  })
+
+  it('tryParseProgramLine', () => {
+    expect(tryParseProgramLine('10 PRINT "X"')).toEqual({
+      lineNum: 10,
+      rest: 'PRINT "X"',
+    })
+    expect(tryParseProgramLine('LOAD "X"')).toBeNull()
+  })
+
+  it('evalNumericExpression', () => {
+    expect(evalNumericExpression('1+2*3')).toBe(7)
+    expect(evalNumericExpression('(1+2)*3')).toBe(9)
+    expect(evalNumericExpression('-5+2')).toBe(-3)
+    expect(evalNumericExpression('')).toBeNull()
+    expect(evalNumericExpression('1+')).toBeNull()
+  })
+
+  it('evalNumericExpression INT, comparisons, power', () => {
+    expect(evalNumericExpression('INT(3.9)')).toBe(3)
+    expect(evalNumericExpression('INT(-3.2)')).toBe(-4)
+    expect(evalNumericExpression('5>3')).toBe(-1)
+    expect(evalNumericExpression('5<3')).toBe(0)
+    expect(evalNumericExpression('2^3')).toBe(8)
+    expect(evalNumericExpression('2^2^2')).toBe(16)
+    expect(evalNumericExpression('SIN(0)')).toBeCloseTo(0)
+  })
+
+  it('assignment and IF THEN run with variables', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'A=2+3')
+    storeProgramLine(p, 20, 'PRINT A')
+    const { lines } = await runCollecting(p, {})
+    expect(lines).toContain('5')
+  })
+
+  it('IF false still runs rest of line after colon', async () => {
+    const p = createBasicProgram()
+    /* No higher line numbers: after 10, RUN ends so we only prove the : PRINT ran. */
+    storeProgramLine(p, 10, 'IF 0 THEN 99: PRINT "OK"')
+    const { lines } = await runCollecting(p, {})
+    expect(lines).toContain('OK')
+  })
+
+  it('IF true branches', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'IF -1 THEN 30')
+    storeProgramLine(p, 20, 'PRINT "SKIP"')
+    storeProgramLine(p, 30, 'PRINT "HERE"')
+    const { lines } = await runCollecting(p, {})
+    expect(lines).toContain('HERE')
+    expect(lines).not.toContain('SKIP')
+  })
+
+  it('nested FOR/NEXT builds logical rows (PRINT newline between rows)', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'FOR Y=1 TO 2')
+    storeProgramLine(p, 20, 'FOR X=1 TO 2')
+    storeProgramLine(p, 30, 'PRINT "*";')
+    storeProgramLine(p, 40, 'NEXT X')
+    storeProgramLine(p, 50, 'PRINT')
+    storeProgramLine(p, 60, 'NEXT Y')
+    const { lines } = await runCollecting(p, {})
+    expect(lines.filter((l) => l === '**').length).toBe(2)
+  })
+
+  it('FOR skips body when range is empty', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'FOR I=1 TO 0')
+    storeProgramLine(p, 20, 'PRINT "BAD"')
+    storeProgramLine(p, 30, 'NEXT I')
+    const { st, lines } = await runCollecting(p, {})
+    expect(st).toBe('completed')
+    expect(lines).not.toContain('BAD')
+  })
+
+  it('NEXT without FOR is an error', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'NEXT I')
+    const { st, lines } = await runCollecting(p, {})
+    expect(st).toBe('syntax_error')
+    expect(lines).toContain('?NEXT WITHOUT FOR')
+  })
+
+  it('RND(1) in numeric expression', () => {
+    const a = evalNumericExpression('RND(1)')
+    const b = evalNumericExpression('RND(1)')
+    expect(a).not.toBeNull()
+    expect(b).not.toBeNull()
+    expect(a!).toBeGreaterThan(0)
+    expect(a!).toBeLessThan(1)
+  })
+
+  it('splitStatements respects quotes', () => {
+    expect(splitStatements('PRINT "A:B": GOTO 10')).toEqual([
+      'PRINT "A:B"',
+      'GOTO 10',
+    ])
+  })
+
+  it('PETSCII maze bytes (PUA U+E0CD / U+E0CE under C64 Pro Mono)', () => {
+    expect(petsciiScreenToChar(205)).toBe('\uE0CD')
+    expect(petsciiScreenToChar(206)).toBe('\uE0CE')
+    expect(c64ByteFromFloat(205.7)).toBe(205)
+    expect(c64ByteFromFloat(206.2)).toBe(206)
+  })
+
+  it('PETSCII high bytes use PUA, not middle-dot fallback', () => {
+    expect(petsciiScreenToChar(210)).toBe('\uE0D2')
+    expect(petsciiScreenToChar(230)).toBe('\uE0E6')
+  })
+
+  it('tryDirectPrint and tryDirectGoto', () => {
+    const pr = tryDirectPrint('print "hello"')
+    expect(pr.ok).toBe(true)
+    if (pr.ok) {
+      expect(opsToRows(pr.ops)).toEqual(['HELLO'])
+    }
+    expect(tryDirectGoto('go to 40')).toBe(40)
+    expect(tryDirectGoto('GOTO 40')).toBe(40)
+  })
+
+  it('tryDirectPrint semicolon suppresses newline row merge', () => {
+    const pr = tryDirectPrint('print "A";')
+    expect(pr.ok).toBe(true)
+    if (pr.ok) {
+      expect(opsToRows(pr.ops)).toEqual(['A'])
+    }
+  })
+
+  it('tryDirectPrint RND advances across separate PRINT lines (d6)', () => {
+    resetDirectEvalContext()
+    const faces = new Set<number>()
+    for (let i = 0; i < 40; i += 1) {
+      const pr = tryDirectPrint('PRINT INT(RND(1)*6)+1')
+      expect(pr.ok).toBe(true)
+      if (pr.ok) {
+        const row = opsToRows(pr.ops)[0]
+        expect(row).toBeDefined()
+        const n = Number(row)
+        expect(n).toBeGreaterThanOrEqual(1)
+        expect(n).toBeLessThanOrEqual(6)
+        faces.add(n)
+      }
+    }
+    expect(faces.size).toBeGreaterThan(1)
+  })
+
+  it('tryDirectPrint (RND(1)>0.5) varies across lines (not stuck at 0)', () => {
+    resetDirectEvalContext()
+    const outs = new Set<string>()
+    for (let i = 0; i < 24; i += 1) {
+      const pr = tryDirectPrint('PRINT (RND(1)>0.5)')
+      expect(pr.ok).toBe(true)
+      if (pr.ok) {
+        outs.add(opsToRows(pr.ops)[0] ?? '')
+      }
+    }
+    expect(outs.has('0')).toBe(true)
+    expect(outs.has('-1')).toBe(true)
+  })
+
+  it('RUN follows GOTO loop until step cap', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PRINT "A"')
+    storeProgramLine(p, 20, 'GOTO 10')
+    const { st, lines } = await runCollecting(p, { maxSteps: 8 })
+    expect(st).toBe('out_of_steps')
+    expect(lines.filter((x) => x === 'A').length).toBeGreaterThanOrEqual(3)
+    expect(lines).toContain('?OUT OF STEPS')
+  })
+
+  it('10 PRINT maze line runs with CHR and RND', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PRINT CHR$(205.5+RND(1)); : GOTO 10')
+    const { st, lines } = await runCollecting(p, { maxSteps: 40 })
+    expect(st).toBe('out_of_steps')
+    const joined = lines.join('')
+    expect(joined).toMatch(/[\uE0CD\uE0CE]+/)
+    expect(lines).toContain('?OUT OF STEPS')
+  })
+
+  it('undefined GOTO target errors', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'GOTO 99')
+    const { st, lines } = await runCollecting(p, {})
+    expect(st).toBe('undef_error')
+    expect(lines).toContain("?UNDEF'D STATEMENT ERROR")
+  })
+
+  it('direct entry line starts at GOTO target', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PRINT "Y"')
+    storeProgramLine(p, 30, 'PRINT "Z"')
+    const { lines } = await runCollecting(p, { entryLine: 30 })
+    expect(lines).toContain('Z')
+    expect(lines).not.toContain('Y')
+  })
+
+  it('GOTO skips sequential lines', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PRINT "A"')
+    storeProgramLine(p, 20, 'GOTO 40')
+    storeProgramLine(p, 30, 'PRINT "SKIP"')
+    storeProgramLine(p, 40, 'PRINT "B"')
+    const { lines } = await runCollecting(p, {})
+    expect(lines).toContain('A')
+    expect(lines).toContain('B')
+    expect(lines).not.toContain('SKIP')
+  })
+
+  it('unknown statement is syntax error', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'FOO')
+    const { st, lines } = await runCollecting(p, {})
+    expect(st).toBe('syntax_error')
+    expect(lines).toContain('?SYNTAX ERROR')
+  })
+
+  it('PRINTFOO does not parse as PRINT', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PRINTFOO')
+    const { st, lines } = await runCollecting(p, {})
+    expect(st).toBe('syntax_error')
+    expect(lines).toContain('?SYNTAX ERROR')
+  })
+
+  it('aborts when signal is already aborted (no statements run)', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PRINT "X"')
+    const ac = new AbortController()
+    ac.abort()
+    const { st, lines } = await runCollecting(p, { signal: ac.signal })
+    expect(st).toBe('aborted')
+    expect(lines).toEqual([])
+  })
+
+  it('aborts mid-run after a timer turn', async () => {
+    const p = createBasicProgram()
+    storeProgramLine(p, 10, 'PRINT "X"')
+    storeProgramLine(p, 20, 'GOTO 10')
+    const ac = new AbortController()
+    const lines: string[] = []
+    let buf = ''
+    const done = runBasicProgram(p, {
+      signal: ac.signal,
+      maxSteps: 100_000,
+      onOutput: (op) => {
+        if (op.op === 'append') buf += op.text
+        else if (op.op === 'newline') {
+          lines.push(buf)
+          buf = ''
+        } else if (op.op === 'lines') {
+          if (buf.length > 0) {
+            lines.push(buf)
+            buf = ''
+          }
+          lines.push(...op.texts)
+        }
+      },
+    })
+    await new Promise<void>((r) => {
+      setTimeout(() => {
+        ac.abort()
+        r()
+      }, 0)
+    })
+    const st = await done
+    if (buf.length > 0) lines.push(buf)
+    expect(st).toBe('aborted')
+  })
+
+  it('default max steps is BASIC_MAX_STEPS', () => {
+    expect(BASIC_MAX_STEPS).toBe(10_000)
+  })
+})

--- a/src/lib/c64-basic.ts
+++ b/src/lib/c64-basic.ts
@@ -1,0 +1,1016 @@
+/**
+ * Commodore-style BASIC for the C64 home terminal (modern teletype adaptation).
+ *
+ * Supported: PRINT (+ ; ,), GOTO, CHR$, RND, INT, SIN, COS, ^ power, comparisons (= < > <> <= >=)
+ * → C64-style -1 / 0 from relations; single-letter variables A–Z and LET/A= assignment;
+ * IF expr THEN line (branch only); FOR/NEXT (nested); multi-statement lines (:) except FOR/NEXT lines
+ * must be a single statement each; step cap; abort.
+ *
+ * Display: output is a character stream (PRINT / ; / ,). “40×25” in listings is a loop count, not pixels —
+ * the responsive terminal may wrap a long logical line across several visual rows; use PRINT alone for a
+ * newline between logical rows (e.g. end each maze row with PRINT).
+ *
+ * Not yet: strings/$, arrays, GOSUB, multi-statement IF THEN … (only THEN line).
+ * Note: C64 BASIC V2 has no ^ operator; we allow ^ for maze demos. RND(1)^2 is intentional sugar.
+ */
+
+export const BASIC_MAX_STEPS = 10_000
+
+export type BasicProgram = Map<number, string>
+
+export function createBasicProgram(): BasicProgram {
+  return new Map()
+}
+
+const UNDEF_ERROR = "?UNDEF'D STATEMENT ERROR"
+const SYNTAX_ERROR = '?SYNTAX ERROR'
+const OUT_OF_STEPS = '?OUT OF STEPS'
+const NEXT_WITHOUT_FOR = '?NEXT WITHOUT FOR'
+
+/** Trim CR/LF; normalize spaces for line entry. */
+export function normalizeInputLine(raw: string): string {
+  return raw.replace(/\r/g, '').trim()
+}
+
+export function tryParseProgramLine(
+  raw: string,
+): { lineNum: number; rest: string } | null {
+  const m = /^\s*(\d+)\s*(.*)$/.exec(raw.replace(/\r/g, ''))
+  if (!m) return null
+  const lineNum = Number.parseInt(m[1], 10)
+  if (!Number.isFinite(lineNum) || lineNum < 0) return null
+  return { lineNum, rest: m[2] ?? '' }
+}
+
+export function canonicalStatement(rest: string): string {
+  const t = rest.trim()
+  if (t.length === 0) return ''
+  return t.toUpperCase()
+}
+
+export type StoreLineResult =
+  | { kind: 'deleted'; lineNum: number }
+  | { kind: 'stored'; lineNum: number; statement: string }
+
+export function storeProgramLine(
+  program: BasicProgram,
+  lineNum: number,
+  rest: string,
+): StoreLineResult {
+  const statement = canonicalStatement(rest)
+  if (statement.length === 0) {
+    program.delete(lineNum)
+    return { kind: 'deleted', lineNum }
+  }
+  program.set(lineNum, statement)
+  return { kind: 'stored', lineNum, statement }
+}
+
+export function formatProgramLineEcho(lineNum: number, rest: string): string {
+  const statement = canonicalStatement(rest)
+  if (statement.length === 0) {
+    return String(lineNum)
+  }
+  return `${lineNum} ${statement}`
+}
+
+export function listProgram(program: ReadonlyMap<number, string>): string[] {
+  const keys = [...program.keys()].sort((a, b) => a - b)
+  return keys.map((n) => `${n} ${program.get(n) ?? ''}`)
+}
+
+// --- PETSCII → Unicode (Style64 C64 Pro Mono: U/G = U+E000 + PETSCII byte) ---
+// https://style64.org/c64-truetype/petscii-rom-mapping — matches CHR$ in graphics mode.
+
+/** Private Use Area base for PETSCII “unshifted / graphics” (same as typing on a C64 in UPPER+GRAPH). */
+const PETSCII_UG_PUA_BASE = 0xe000
+
+/** C64-style float → byte for CHR$ / screen code. */
+export function c64ByteFromFloat(x: number): number {
+  const i = Math.floor(x)
+  return ((i % 256) + 256) % 256
+}
+
+export function petsciiScreenToChar(code: number): string {
+  const b = c64ByteFromFloat(code)
+  if (b >= 32 && b <= 126) {
+    return String.fromCharCode(b)
+  }
+  return String.fromCharCode(PETSCII_UG_PUA_BASE + b)
+}
+
+// --- RND (C64-ish: x>0 → (0,1), x=0 → repeat last, x<0 → reseed) ---
+
+function randomRndSeed32(): number {
+  try {
+    const c = globalThis.crypto
+    if (c?.getRandomValues) {
+      const buf = new Uint32Array(1)
+      c.getRandomValues(buf)
+      return buf[0]! >>> 0
+    }
+  } catch {
+    // ignore (e.g. locked-down environment)
+  }
+  return 0xace1
+}
+
+export class RndGen {
+  private seed: number
+  private last = 0.731056431
+
+  /** Omit `seed` for a session-unique starting point when `crypto` is available (else 0xace1). */
+  constructor(seed?: number) {
+    this.seed = seed !== undefined ? seed >>> 0 : randomRndSeed32()
+  }
+
+  rnd(x: number): number {
+    if (x < 0) {
+      const s = Math.abs(Math.floor(x * 1_000_007)) ^ 0x9e3779b9
+      this.seed = s === 0 ? 0xdeadbeef : s >>> 0
+      this.next01()
+      return this.last
+    }
+    if (x > 0) {
+      this.last = this.next01()
+      return this.last
+    }
+    return this.last
+  }
+
+  private next01(): number {
+    this.seed = (Math.imul(1664525, this.seed) + 1013904223) >>> 0
+    const u = this.seed / 0x1_0000_0000
+    const eps = 1e-12
+    return Math.min(1 - eps, Math.max(eps, u))
+  }
+}
+
+// --- Split : outside quotes ---
+
+/** Split `:` outside quotes (multi-statement BASIC lines). */
+export function splitStatements(line: string): string[] {
+  const parts: string[] = []
+  let start = 0
+  let i = 0
+  let inStr = false
+  while (i < line.length) {
+    const c = line[i]
+    if (c === '"') {
+      inStr = !inStr
+    } else if (!inStr && c === ':') {
+      const chunk = line.slice(start, i).trim()
+      if (chunk.length > 0) parts.push(chunk)
+      start = i + 1
+    }
+    i += 1
+  }
+  const last = line.slice(start).trim()
+  if (last.length > 0) parts.push(last)
+  return parts
+}
+
+function skipWs(s: string, i: number): number {
+  let j = i
+  while (j < s.length && /\s/.test(s[j])) j += 1
+  return j
+}
+
+function isGotoStatement(stmt: string): boolean {
+  const u = stmt.trim().toUpperCase()
+  return u.startsWith('GOTO') || /^GO\s+TO\b/i.test(stmt.trim())
+}
+
+function parseGotoLine(stmt: string): number | null {
+  const t = stmt.trim()
+  let m = /^\s*GOTO\s+(\d+)\s*$/i.exec(t)
+  if (m) return Number.parseInt(m[1], 10)
+  m = /^\s*GO\s+TO\s+(\d+)\s*$/i.exec(t)
+  if (m) return Number.parseInt(m[1], 10)
+  return null
+}
+
+/** `IF expr THEN line` only (no THEN PRINT / THEN : …). */
+function parseIfThenLine(stmt: string): { cond: string; target: number } | null {
+  const t = stmt.trim()
+  if (!t.toUpperCase().startsWith('IF')) {
+    return null
+  }
+  const thenM = /\bTHEN\b/i.exec(t)
+  if (thenM === null || thenM.index < 2) {
+    return null
+  }
+  const cond = t.slice(2, thenM.index).trim()
+  if (cond.length === 0) {
+    return null
+  }
+  const after = t.slice(thenM.index + thenM[0].length).trim()
+  const num = /^(\d+)\s*$/.exec(after)
+  if (num === null) {
+    return null
+  }
+  const target = Number.parseInt(num[1], 10)
+  if (!Number.isFinite(target)) {
+    return null
+  }
+  return { cond, target }
+}
+
+function skipWsGlobal(s: string, j: number): number {
+  let k = j
+  while (k < s.length && /\s/.test(s[k]!)) k += 1
+  return k
+}
+
+/**
+ * `FOR V = expr TO expr [STEP expr]` — one statement per line (no `:` on that line).
+ */
+function parseForLine(stmt: string): {
+  var: string
+  startS: string
+  limitS: string
+  stepS: string
+} | null {
+  const t = stmt.trim()
+  if (!/^\s*FOR\b/i.test(t)) {
+    return null
+  }
+  let i = (/^\s*FOR\b/i.exec(t) ?? [''])[0].length
+  i = skipWsGlobal(t, i)
+  if (i >= t.length || !/[A-Z]/i.test(t[i]!)) {
+    return null
+  }
+  const v = t[i]!.toUpperCase()
+  if (v < 'A' || v > 'Z') {
+    return null
+  }
+  i += 1
+  i = skipWsGlobal(t, i)
+  if (t[i] !== '=') {
+    return null
+  }
+  i += 1
+  const start0 = i
+  let depth = 0
+  let toIdx = -1
+  while (i < t.length) {
+    const c = t[i]!
+    if (c === '(') {
+      depth += 1
+    } else if (c === ')') {
+      depth -= 1
+    }
+    if (depth === 0 && /^\s*TO\b/i.test(t.slice(i))) {
+      toIdx = i
+      break
+    }
+    i += 1
+  }
+  if (toIdx < 0) {
+    return null
+  }
+  const startS = t.slice(start0, toIdx).trim()
+  const toMatch = /^\s*TO\b/i.exec(t.slice(toIdx))
+  if (toMatch === null) {
+    return null
+  }
+  i = toIdx + toMatch[0].length
+  const lim0 = i
+  depth = 0
+  let stepIdx = -1
+  while (i < t.length) {
+    const c = t[i]!
+    if (c === '(') {
+      depth += 1
+    } else if (c === ')') {
+      depth -= 1
+    }
+    if (depth === 0 && /^\s*STEP\b/i.test(t.slice(i))) {
+      stepIdx = i
+      break
+    }
+    i += 1
+  }
+  let limitS: string
+  let stepS = '1'
+  if (stepIdx >= 0) {
+    limitS = t.slice(lim0, stepIdx).trim()
+    const sm = /^\s*STEP\b/i.exec(t.slice(stepIdx))
+    if (sm === null) {
+      return null
+    }
+    stepS = t.slice(stepIdx + sm[0].length).trim()
+  } else {
+    limitS = t.slice(lim0).trim()
+  }
+  if (startS.length === 0 || limitS.length === 0 || stepS.length === 0) {
+    return null
+  }
+  return { var: v, startS, limitS, stepS }
+}
+
+/** `NEXT` or `NEXT V` — one statement per line. */
+function parseNextLine(stmt: string): { var?: string } | null {
+  const t = stmt.trim()
+  const m = /^\s*NEXT\b(.*)$/i.exec(t)
+  if (m === null) {
+    return null
+  }
+  const rest = (m[1] ?? '').trim().toUpperCase()
+  if (rest.length === 0) {
+    return {}
+  }
+  if (/^[A-Z]$/.test(rest)) {
+    return { var: rest }
+  }
+  return null
+}
+
+type ForFrame = {
+  var: string
+  limit: number
+  step: number
+  bodyEntryLine: number
+}
+
+/** Single-letter variable A–Z; optional leading LET. */
+function parseAssignStatement(stmt: string): { name: string; expr: string } | null {
+  let t = stmt.trim()
+  const letM = /^LET\s+/i.exec(t)
+  if (letM !== null) {
+    t = t.slice(letM[0].length).trim()
+  }
+  const m = /^([A-Z])\s*=\s*(.+)$/i.exec(t)
+  if (m === null) {
+    return null
+  }
+  const name = m[1].toUpperCase()
+  const expr = m[2].trim()
+  if (expr.length === 0) {
+    return null
+  }
+  return { name, expr }
+}
+
+// --- Value / numeric eval (RND, + - * /, parens) ---
+
+type Value = { kind: 'num'; n: number } | { kind: 'str'; s: string }
+
+function formatPrintNumber(n: number): string {
+  if (Number.isInteger(n) && Math.abs(n) <= 1e15) {
+    return String(n)
+  }
+  return String(n)
+}
+
+/** Strip spaces for numeric tokenizer. */
+function stripExprWs(s: string): string {
+  return s.replace(/\s/g, '')
+}
+
+export type BasicEvalContext = {
+  rnd: RndGen
+  vars: Map<string, number>
+}
+
+function createEmptyEvalContext(): BasicEvalContext {
+  return { rnd: new RndGen(), vars: new Map<string, number>() }
+}
+
+/**
+ * Direct statements typed at READY. share one RNG and variable map (like one interactive session).
+ * Without this, each `PRINT` used a fresh `RndGen` and `RND(1)` repeated the same value.
+ */
+const directModeEvalContext: BasicEvalContext = {
+  rnd: new RndGen(),
+  vars: new Map<string, number>(),
+}
+
+/** Clears direct-mode variables and reseeds RND; call when the user enters NEW. */
+export function resetDirectEvalContext(): void {
+  directModeEvalContext.rnd = new RndGen()
+  directModeEvalContext.vars.clear()
+}
+
+export function evalNumericExpression(expr: string): number | null {
+  return evalNumericWithContext(stripExprWs(expr), createEmptyEvalContext())
+}
+
+function evalNumericWithContext(s: string, ctx: BasicEvalContext): number | null {
+  let i = 0
+  const peek = () => s[i]
+  const eat = (c: string) => {
+    if (peek() === c) {
+      i += 1
+      return true
+    }
+    return false
+  }
+
+  const { rnd, vars } = ctx
+
+  function parseRndArg(): number | null {
+    if (!eat('(')) return null
+    const inner = parseComparison()
+    if (inner === null || !eat(')')) return null
+    return inner
+  }
+
+  function parsePrimary(): number | null {
+    if (eat('(')) {
+      const inner = parseComparison()
+      if (inner === null || !eat(')')) return null
+      return inner
+    }
+    if (peek() === '-') {
+      i += 1
+      const v = parsePrimary()
+      return v === null ? null : -v
+    }
+    const rest = s.slice(i).toUpperCase()
+    if (rest.startsWith('RND')) {
+      i += 3
+      const arg = parseRndArg()
+      if (arg === null) return null
+      return rnd.rnd(arg)
+    }
+    if (rest.startsWith('INT')) {
+      i += 3
+      if (!eat('(')) return null
+      const inner = parseComparison()
+      if (inner === null || !eat(')')) return null
+      return Math.floor(inner)
+    }
+    if (rest.startsWith('SIN')) {
+      i += 3
+      if (!eat('(')) return null
+      const inner = parseComparison()
+      if (inner === null || !eat(')')) return null
+      return Math.sin(inner)
+    }
+    if (rest.startsWith('COS')) {
+      i += 3
+      if (!eat('(')) return null
+      const inner = parseComparison()
+      if (inner === null || !eat(')')) return null
+      return Math.cos(inner)
+    }
+    const num = parseNumber()
+    if (num !== null) return num
+    if (/[A-Z]/.test(peek() ?? '')) {
+      const name = peek()!
+      i += 1
+      return vars.get(name) ?? 0
+    }
+    return null
+  }
+
+  function parseNumber(): number | null {
+    const start = i
+    if (peek() === '-') {
+      i += 1
+    }
+    let sawDigit = false
+    while (i < s.length && /[0-9]/.test(s[i])) {
+      sawDigit = true
+      i += 1
+    }
+    if (peek() === '.') {
+      i += 1
+      while (i < s.length && /[0-9]/.test(s[i])) {
+        sawDigit = true
+        i += 1
+      }
+    }
+    if (!sawDigit) {
+      i = start
+      return null
+    }
+    const n = Number.parseFloat(s.slice(start, i))
+    return Number.isFinite(n) ? n : null
+  }
+
+  /** Right-associative ^ (not on stock C64 BASIC; useful for demos). */
+  function parseExponent(): number | null {
+    const left = parsePrimary()
+    if (left === null) return null
+    if (peek() === '^') {
+      i += 1
+      const right = parseExponent()
+      if (right === null) return null
+      return Math.pow(left, right)
+    }
+    return left
+  }
+
+  function parseFactor(): number | null {
+    let left = parseExponent()
+    if (left === null) return null
+    while (peek() === '*' || peek() === '/') {
+      const op = peek()
+      i += 1
+      const right = parseExponent()
+      if (right === null) return null
+      left = op === '*' ? left * right : left / right
+    }
+    return left
+  }
+
+  function parseExpr(): number | null {
+    let left = parseFactor()
+    if (left === null) return null
+    while (peek() === '+' || peek() === '-') {
+      const op = peek()
+      i += 1
+      const right = parseFactor()
+      if (right === null) return null
+      left = op === '+' ? left + right : left - right
+    }
+    return left
+  }
+
+  /** Relations yield -1 (true) or 0 (false), like Commodore BASIC numeric comparisons. */
+  function parseComparison(): number | null {
+    const left = parseExpr()
+    if (left === null) return null
+    if (i >= s.length) return left
+
+    const c0 = peek()
+    if (c0 === '<') {
+      i += 1
+      if (eat('>')) {
+        const r = parseExpr()
+        if (r === null) return null
+        return left !== r ? -1 : 0
+      }
+      if (eat('=')) {
+        const r = parseExpr()
+        if (r === null) return null
+        return left <= r ? -1 : 0
+      }
+      const r = parseExpr()
+      if (r === null) return null
+      return left < r ? -1 : 0
+    }
+    if (c0 === '>') {
+      i += 1
+      if (eat('=')) {
+        const r = parseExpr()
+        if (r === null) return null
+        return left >= r ? -1 : 0
+      }
+      const r = parseExpr()
+      if (r === null) return null
+      return left > r ? -1 : 0
+    }
+    if (c0 === '=') {
+      i += 1
+      const r = parseExpr()
+      if (r === null) return null
+      return left === r ? -1 : 0
+    }
+    return left
+  }
+
+  const v = parseComparison()
+  if (v === null || i !== s.length) return null
+  return v
+}
+
+function matchChr$(s: string, start: number): { innerStart: number; end: number } | null {
+  const u = s.slice(start).toUpperCase()
+  if (!u.startsWith('CHR$(')) return null
+  let j = start + 'CHR$('.length
+  let depth = 1
+  while (j < s.length && depth > 0) {
+    const c = s[j]
+    if (c === '(') depth += 1
+    else if (c === ')') depth -= 1
+    j += 1
+  }
+  if (depth !== 0) return null
+  return { innerStart: start + 'CHR$('.length, end: j }
+}
+
+function evalValueExpr(slice: string, ctx: BasicEvalContext): Value | null {
+  const t = slice.trim()
+  if (t.length === 0) return { kind: 'str', s: '' }
+  const ws0 = skipWs(t, 0)
+  const mchr = matchChr$(t, ws0)
+  if (mchr !== null && skipWs(t, mchr.end) === t.length) {
+    const inner = t.slice(mchr.innerStart, mchr.end - 1)
+    const n = evalNumericWithContext(stripExprWs(inner), ctx)
+    if (n === null) return null
+    const b = c64ByteFromFloat(n)
+    return { kind: 'str', s: petsciiScreenToChar(b) }
+  }
+  const n = evalNumericWithContext(stripExprWs(t), ctx)
+  if (n === null) return null
+  return { kind: 'num', n }
+}
+
+function findPrintItemEnd(tail: string, start: number): number {
+  let i = skipWs(tail, start)
+  if (i >= tail.length) return i
+  if (tail[i] === '"') {
+    i += 1
+    while (i < tail.length) {
+      if (tail[i] === '"') {
+        i += 1
+        break
+      }
+      i += 1
+    }
+    return i
+  }
+  let depth = 0
+  while (i < tail.length) {
+    const c = tail[i]
+    if (c === '"') {
+      i += 1
+      while (i < tail.length && tail[i] !== '"') i += 1
+      if (i < tail.length) i += 1
+      continue
+    }
+    if (c === '(') depth += 1
+    else if (c === ')' && depth > 0) depth -= 1
+    else if (depth === 0 && (c === ';' || c === ',')) return i
+    i += 1
+  }
+  return i
+}
+
+function executePrintTail(
+  tail: string,
+  ctx: BasicEvalContext,
+  emit: (op: BasicOutputOp) => void,
+): boolean {
+  let i = skipWs(tail, 0)
+  let needNewline = true
+
+  const doAppend = (text: string) => {
+    if (text.length > 0) emit({ op: 'append', text })
+  }
+
+  while (i < tail.length) {
+    i = skipWs(tail, i)
+    if (i >= tail.length) break
+
+    const c = tail[i]
+    if (c === ';') {
+      needNewline = false
+      i += 1
+      continue
+    }
+    if (c === ',') {
+      doAppend('  ')
+      needNewline = false
+      i += 1
+      continue
+    }
+
+    if (c === '"') {
+      let j = i + 1
+      let out = ''
+      while (j < tail.length && tail[j] !== '"') {
+        out += tail[j]
+        j += 1
+      }
+      if (j >= tail.length) return false
+      j += 1
+      doAppend(out.toUpperCase())
+      i = j
+      continue
+    }
+
+    const end = findPrintItemEnd(tail, i)
+    const piece = tail.slice(i, end).trim()
+    if (piece.length > 0) {
+      const v = evalValueExpr(piece, ctx)
+      if (v === null) return false
+      if (v.kind === 'num') doAppend(formatPrintNumber(v.n))
+      else doAppend(v.s)
+    }
+    i = end
+  }
+
+  if (needNewline) emit({ op: 'newline' })
+  return true
+}
+
+export function parseBasicPrintStatement(
+  stmt: string,
+): { ok: true; text: string } | { ok: false } {
+  const m = /^\s*PRINT\b\s*(.*)$/i.exec(stmt)
+  if (!m) return { ok: false }
+  const ctx = createEmptyEvalContext()
+  const parts: string[] = []
+  const ok = executePrintTail(m[1] ?? '', ctx, (op) => {
+    if (op.op === 'append') parts.push(op.text)
+    if (op.op === 'newline') parts.push('\n')
+  })
+  if (!ok) return { ok: false }
+  return { ok: true, text: parts.join('').replace(/\n$/, '') }
+}
+
+function nextLineNum(current: number, sortedLines: number[]): number | null {
+  const idx = sortedLines.findIndex((n) => n > current)
+  return idx === -1 ? null : sortedLines[idx]!
+}
+
+type AfterNextResult = number | 'past_end' | null
+
+/** `null` = no matching NEXT; `past_end` = NEXT on last line (run ends after skip). */
+function findLineAfterMatchingNext(
+  program: ReadonlyMap<number, string>,
+  sortedLines: number[],
+  forLineNum: number,
+): AfterNextResult {
+  let depth = 1
+  const fromIdx = sortedLines.findIndex((n) => n > forLineNum)
+  if (fromIdx < 0) {
+    return null
+  }
+  for (let li = fromIdx; li < sortedLines.length; li += 1) {
+    const ln = sortedLines[li]!
+    const text = program.get(ln)
+    if (text === undefined) {
+      continue
+    }
+    const subs = splitStatements(text)
+    for (const sub of subs) {
+      const tr = sub.trim()
+      if (parseForLine(tr) !== null) {
+        depth += 1
+        continue
+      }
+      if (parseNextLine(tr) !== null) {
+        depth -= 1
+        if (depth === 0) {
+          const nxt = nextLineNum(ln, sortedLines)
+          return nxt === null ? 'past_end' : nxt
+        }
+        if (depth < 0) {
+          return null
+        }
+      }
+    }
+  }
+  return null
+}
+
+async function yieldToEventLoop(): Promise<void> {
+  await new Promise<void>((r) => {
+    setTimeout(r, 0)
+  })
+}
+
+export type BasicRunStatus =
+  | 'completed'
+  | 'syntax_error'
+  | 'undef_error'
+  | 'out_of_steps'
+  | 'aborted'
+
+export type BasicOutputOp =
+  | { op: 'append'; text: string }
+  | { op: 'newline' }
+  | { op: 'lines'; texts: string[] }
+
+export interface RunBasicProgramOptions {
+  entryLine?: number
+  maxSteps?: number
+  signal?: AbortSignal
+  /** Stream: append / newline for PRINT; lines for errors and multi-line messages. */
+  onOutput: (op: BasicOutputOp) => void
+}
+
+function emitLines(onOutput: (op: BasicOutputOp) => void, texts: string[]) {
+  onOutput({ op: 'lines', texts })
+}
+
+export async function runBasicProgram(
+  program: ReadonlyMap<number, string>,
+  options: RunBasicProgramOptions,
+): Promise<BasicRunStatus> {
+  const maxSteps = options.maxSteps ?? BASIC_MAX_STEPS
+  const sortedLines = [...program.keys()].sort((a, b) => a - b)
+  const signal = options.signal
+  const ctx: BasicEvalContext = { rnd: new RndGen(), vars: new Map<string, number>() }
+  const { onOutput } = options
+  const forStack: ForFrame[] = []
+
+  if (sortedLines.length === 0) {
+    return 'completed'
+  }
+
+  let pc: number | null =
+    options.entryLine !== undefined ? options.entryLine : sortedLines[0]!
+
+  let steps = 0
+
+  while (pc !== null) {
+    if (signal?.aborted) {
+      return 'aborted'
+    }
+
+    steps += 1
+    if (steps > maxSteps) {
+      emitLines(onOutput, [OUT_OF_STEPS])
+      return 'out_of_steps'
+    }
+
+    await yieldToEventLoop()
+
+    const stmtLine = program.get(pc)
+    if (stmtLine === undefined) {
+      emitLines(onOutput, [UNDEF_ERROR])
+      return 'undef_error'
+    }
+
+    const subs = splitStatements(stmtLine)
+    let jumped: number | null = null
+    let exitRun = false
+
+    for (const sub of subs) {
+      const trimmed = sub.trim()
+
+      const ifThen = parseIfThenLine(trimmed)
+      if (ifThen !== null) {
+        const condVal = evalNumericWithContext(stripExprWs(ifThen.cond), ctx)
+        if (condVal === null) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        if (condVal !== 0) {
+          if (!program.has(ifThen.target)) {
+            emitLines(onOutput, [UNDEF_ERROR])
+            return 'undef_error'
+          }
+          jumped = ifThen.target
+          break
+        }
+        /* false: done with this sub; remaining subs (after :) still run */
+        continue
+      }
+
+      const printMatch = /^\s*PRINT\b(.*)$/i.exec(trimmed)
+      if (printMatch) {
+        const ok = executePrintTail(printMatch[1] ?? '', ctx, onOutput)
+        if (!ok) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        continue
+      }
+
+      if (isGotoStatement(trimmed)) {
+        const target = parseGotoLine(trimmed)
+        if (target === null) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        if (!program.has(target)) {
+          emitLines(onOutput, [UNDEF_ERROR])
+          return 'undef_error'
+        }
+        jumped = target
+        break
+      }
+
+      const nextParsed = parseNextLine(trimmed)
+      if (nextParsed !== null) {
+        if (subs.length > 1) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        if (forStack.length === 0) {
+          emitLines(onOutput, [NEXT_WITHOUT_FOR])
+          return 'syntax_error'
+        }
+        const top = forStack[forStack.length - 1]!
+        if (nextParsed.var !== undefined && nextParsed.var !== top.var) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        const cur = (ctx.vars.get(top.var) ?? 0) + top.step
+        ctx.vars.set(top.var, cur)
+        const cont =
+          (top.step > 0 && cur <= top.limit) ||
+          (top.step < 0 && cur >= top.limit)
+        if (cont) {
+          jumped = top.bodyEntryLine
+          break
+        }
+        forStack.pop()
+        continue
+      }
+
+      const forParsed = parseForLine(trimmed)
+      if (forParsed !== null) {
+        if (subs.length > 1) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        const start = evalNumericWithContext(stripExprWs(forParsed.startS), ctx)
+        const limit = evalNumericWithContext(stripExprWs(forParsed.limitS), ctx)
+        const stepVal = evalNumericWithContext(stripExprWs(forParsed.stepS), ctx)
+        if (start === null || limit === null || stepVal === null) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        if (stepVal === 0) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        ctx.vars.set(forParsed.var, start)
+        const bodyEntry = nextLineNum(pc, sortedLines)
+        const cont =
+          (stepVal > 0 && start <= limit) ||
+          (stepVal < 0 && start >= limit)
+        if (!cont) {
+          const after = findLineAfterMatchingNext(program, sortedLines, pc)
+          if (after === null) {
+            emitLines(onOutput, [SYNTAX_ERROR])
+            return 'syntax_error'
+          }
+          if (after === 'past_end') {
+            exitRun = true
+          } else {
+            jumped = after
+          }
+          break
+        }
+        if (bodyEntry === null) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        forStack.push({
+          var: forParsed.var,
+          limit,
+          step: stepVal,
+          bodyEntryLine: bodyEntry,
+        })
+        continue
+      }
+
+      const assign = parseAssignStatement(trimmed)
+      if (assign !== null) {
+        const v = evalNumericWithContext(stripExprWs(assign.expr), ctx)
+        if (v === null) {
+          emitLines(onOutput, [SYNTAX_ERROR])
+          return 'syntax_error'
+        }
+        ctx.vars.set(assign.name, v)
+        continue
+      }
+
+      emitLines(onOutput, [SYNTAX_ERROR])
+      return 'syntax_error'
+    }
+
+    if (exitRun) {
+      pc = null
+    } else if (jumped !== null) {
+      pc = jumped
+    } else {
+      pc = nextLineNum(pc, sortedLines)
+    }
+  }
+
+  return 'completed'
+}
+
+export function tryDirectPrint(
+  raw: string,
+): { ok: true; ops: BasicOutputOp[] } | { ok: false } {
+  const t = normalizeInputLine(raw)
+  const m = /^\s*PRINT\b(.*)$/i.exec(t)
+  if (!m) return { ok: false }
+  const ops: BasicOutputOp[] = []
+  const ok = executePrintTail(m[1] ?? '', directModeEvalContext, (op) => {
+    ops.push(op)
+  })
+  if (!ok) return { ok: false }
+  return { ok: true, ops }
+}
+
+export function tryDirectGoto(raw: string): number | null {
+  const t = normalizeInputLine(raw)
+  if (!isGotoStatement(t)) return null
+  return parseGotoLine(t)
+}
+
+export function isDirectList(raw: string): boolean {
+  return normalizeInputLine(raw).toUpperCase() === 'LIST'
+}
+
+export function isDirectNew(raw: string): boolean {
+  return normalizeInputLine(raw).toUpperCase() === 'NEW'
+}
+
+export function isDirectRun(raw: string): boolean {
+  return normalizeInputLine(raw).toUpperCase() === 'RUN'
+}
+
+export { SYNTAX_ERROR, UNDEF_ERROR, OUT_OF_STEPS }

--- a/src/lib/c64-settings.ts
+++ b/src/lib/c64-settings.ts
@@ -12,6 +12,11 @@ export const LEGACY_SITE_THEME_KEY = 'site-theme'
  * Used when boot mode is `session`.
  */
 export const C64_HOME_BOOT_LINES_SESSION_KEY = 'c64-home-boot-lines-done'
+/**
+ * First full-page pathname in this tab (set inline in site layout). Used to defer the home CRT boot
+ * until drawers are closed when the user did not land on `/` first.
+ */
+export const C64_SESSION_ENTRY_PATH_KEY = 'c64-session-entry-path'
 
 export type C64Accent =
   | 'classic'

--- a/src/lib/c64-settings.ts
+++ b/src/lib/c64-settings.ts
@@ -40,7 +40,7 @@ export interface C64Settings {
 export const defaultC64Settings: C64Settings = {
   accent: 'classic',
   screenTint: 'default',
-  scanlines: false,
+  scanlines: true,
   boot: 'session',
   textScale: 'comfortable',
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,11 @@ const dirname =
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.join(dirname, 'src'),
+    },
+  },
   test: {
     projects: [
       {
@@ -28,6 +33,13 @@ export default defineConfig({
         instances: [{ browser: 'chromium' }]
       },
           setupFiles: ['.storybook/vitest.setup.ts'],
+        },
+      },
+      {
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
         },
       },
     ],


### PR DESCRIPTION
**Summary**
Adds a small Commodore-style BASIC runtime to the authentic C64 home terminal (not full BASIC V2), plus tighter disk / LIST behavior and supporting docs/tests.

**What’s in it**

BASIC: Numbered lines, LIST / NEW / RUN, PRINT (incl. CHR$, RND, INT, trig, compares, ^), A–Z, IF … THEN line, GOTO, FOR/NEXT, : (with the existing FOR/NEXT restriction), step limit + stop controls.
Disk: Closing a site drawer replays LOAD"$",8 → SEARCHING → LOADING → READY → LIST and the clickable catalog. Typed LOAD "$",8 clears stored BASIC so LIST shows the disk catalog again (C64-style overwrite).
Quality: Vitest coverage for c64-basic; updates to C64_TERMINAL_BASIC.md and related home docs.
**Notes**
No INPUT, string vars, or arrays yet — interactive games still need more language surface.