### PR TITLE
chore: UI polish and fixes (C64 forms, contrast, markdown, boot speed)

### DIFF
--- a/src/app/(site)/field-notes/[slug]/page.tsx
+++ b/src/app/(site)/field-notes/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default function FieldNotePage({ params }: { params: Promise<{ slug: stri
           <>
             {/* Desktop: "Field notes / Title" pattern */}
             <span className="hidden md:inline">
-              <span className="text-muted-foreground">Field notes</span>
+              <span className="text-[#ffffff]/75">Field notes</span>
               {noteTitle && (
                 <span 
                   className="transition-opacity duration-300 ease-in-out"
@@ -43,15 +43,15 @@ export default function FieldNotePage({ params }: { params: Promise<{ slug: stri
                     display: 'inline'
                   }}
                 >
-                  <span className="mx-2 text-muted-foreground">/</span>
-                  <span>{noteTitle}</span>
+                  <span className="mx-2 text-[#ffffff]/45">/</span>
+                  <span className="text-[#ffffff]">{noteTitle}</span>
                 </span>
               )}
             </span>
             
             {/* Mobile: Show nothing until title scrolls into sticky state; when shown, use 16px */}
             {(!isTitleVisible && noteTitle) ? (
-              <span className="md:hidden text-base" style={{ whiteSpace: 'nowrap' }}>{noteTitle}</span>
+              <span className="md:hidden text-base text-[#ffffff]" style={{ whiteSpace: 'nowrap' }}>{noteTitle}</span>
             ) : null}
           </>
         }

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -14,7 +14,7 @@ const C64_INLINE_INIT = `
   var TABLE=${C64_INLINE_THEME_VARS_JSON};
   var el=document.getElementById('c64-site-root');
   if(!el)return;
-  var def={accent:'classic',screenTint:'default',scanlines:true,boot:'session',textScale:'comfortable'};
+  var def={accent:'classic',screenTint:'default',scanlines:false,boot:'session'};
   var s=def;
   try{var r=localStorage.getItem('site-c64-settings');if(r)s=Object.assign({},def,JSON.parse(r));}catch(e){}
   if(s.accent==='cyan'||s.accent==='lightblue')s.accent='classic';
@@ -22,8 +22,7 @@ const C64_INLINE_INIT = `
   var tint=s.screenTint in TABLE[accent]?s.screenTint:'default';
   var vars=TABLE[accent][tint];
   for(var k in vars){if(Object.prototype.hasOwnProperty.call(vars,k))el.style.setProperty(k,vars[k]);}
-  var scale=s.textScale==='compact'?'0.9':'1.05';
-  el.style.setProperty('--c64-text-scale',scale);
+  el.style.setProperty('--c64-text-scale','1.05');
   el.dataset.c64Scanlines=s.scanlines?'on':'off';
   el.dataset.c64Boot=s.boot||'session';
   try{

--- a/src/app/(site)/selected-works/[slug]/page.tsx
+++ b/src/app/(site)/selected-works/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default function SelectedWorkPage({ params }: { params: Promise<{ slug: s
           <>
             {/* Desktop: "Selected works / Title" pattern */}
             <span className="hidden md:inline">
-              <span className="text-muted-foreground">Selected works</span>
+              <span className="text-[#ffffff]/75">Selected works</span>
               {workTitle && (
                 <span 
                   className="transition-opacity duration-300 ease-in-out"
@@ -43,15 +43,15 @@ export default function SelectedWorkPage({ params }: { params: Promise<{ slug: s
                     display: 'inline'
                   }}
                 >
-                  <span className="mx-2 text-muted-foreground">/</span>
-                  <span>{workTitle}</span>
+                  <span className="mx-2 text-[#ffffff]/45">/</span>
+                  <span className="text-[#ffffff]">{workTitle}</span>
                 </span>
               )}
             </span>
             
             {/* Mobile: Show nothing until title scrolls into sticky state; when shown, use 16px */}
             {(!isTitleVisible && workTitle) ? (
-              <span className="md:hidden text-base" style={{ whiteSpace: 'nowrap' }}>{workTitle}</span>
+              <span className="md:hidden text-base text-[#ffffff]" style={{ whiteSpace: 'nowrap' }}>{workTitle}</span>
             ) : null}
           </>
         }

--- a/src/app/(site)/sign-in/page.tsx
+++ b/src/app/(site)/sign-in/page.tsx
@@ -2,16 +2,32 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { Input } from '@headlessui/react'
+import { clsx } from 'clsx'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import LevinMediaLogo from '@/app/components/LevinMediaLogo'
 import Button from '@/app/components/Button'
-import Input from '@/app/components/ui/Input'
+import { c64FormFieldClass, c64FormFieldLabelClass } from '@/lib/c64-form-classes'
+
+const c64FieldErrorClass =
+  'mt-2 border-2 border-[#ee4444] bg-[var(--c64-border-bg)]/40 px-3 py-2 text-base font-bold uppercase tracking-[0.06em] text-[#ffb4b4]'
+
+const c64FormErrorBannerClass =
+  'border-4 border-[#ee4444] bg-[var(--c64-border-bg)]/35 p-4 text-base font-bold uppercase tracking-[0.06em] text-[#ffb4b4]'
+
+function isValidEmail(value: string): boolean {
+  const t = value.trim()
+  if (!t) return false
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(t)
+}
+
 export default function SignInPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
+  const [fieldErrors, setFieldErrors] = useState<{ email?: string; password?: string }>({})
   const router = useRouter()
 
   useEffect(() => {
@@ -35,10 +51,28 @@ export default function SignInPage() {
     checkAdminExists()
   }, [router])
 
+  const validateFields = (): boolean => {
+    const next: { email?: string; password?: string } = {}
+    if (!email.trim()) {
+      next.email = 'Email address is required'
+    } else if (!isValidEmail(email)) {
+      next.email = 'Enter a valid email address'
+    }
+    if (!password) {
+      next.password = 'Password is required'
+    }
+    setFieldErrors(next)
+    return Object.keys(next).length === 0
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setIsLoading(true)
     setError('')
+    if (!validateFields()) {
+      return
+    }
+
+    setIsLoading(true)
 
     try {
       const response = await fetch('/api/admin/auth', {
@@ -51,6 +85,7 @@ export default function SignInPage() {
 
       const contentType = response.headers.get('content-type')
       if (!contentType || !contentType.includes('application/json')) {
+        setFieldErrors({})
         setError('Server error: Received invalid response. Please check your environment variables.')
         return
       }
@@ -58,11 +93,13 @@ export default function SignInPage() {
       const data = await response.json()
 
       if (!response.ok) {
+        setFieldErrors({})
         setError(data.error || 'Login failed')
         return
       }
 
       if (data.cookie_error) {
+        setFieldErrors({})
         setError(data.cookie_error)
         return
       }
@@ -73,6 +110,7 @@ export default function SignInPage() {
         router.push('/')
       }
     } catch {
+      setFieldErrors({})
       setError('An error occurred. Please try again.')
     } finally {
       setIsLoading(false)
@@ -98,37 +136,58 @@ export default function SignInPage() {
         </div>
 
         <div className="bg-[var(--c64-border-bg)] border-4 border-[var(--c64-accent)] c64-petscii-frame p-8 c64-screen-grid">
-          <form className="space-y-6" onSubmit={handleSubmit}>
+          <form className="space-y-6" onSubmit={handleSubmit} noValidate>
             <div className="space-y-4">
-              <Input
-                label="Email Address"
-                id="email"
-                name="email"
-                type="email"
-                required
-                placeholder="Enter your email address"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="rounded-none"
-              />
-              <div className="space-y-2">
-                <label htmlFor="password" className="block text-sm font-medium text-foreground">
+              <div>
+                <label htmlFor="email" className={`${c64FormFieldLabelClass} mb-2`}>
+                  Email Address
+                </label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  aria-invalid={fieldErrors.email ? true : undefined}
+                  aria-describedby={fieldErrors.email ? 'sign-in-email-error' : undefined}
+                  placeholder="Enter your email address"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value)
+                    setError('')
+                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
+                  }}
+                  className={clsx(c64FormFieldClass, fieldErrors.email && '!border-[#ee4444]')}
+                />
+                {fieldErrors.email ? (
+                  <p id="sign-in-email-error" role="alert" className={c64FieldErrorClass}>
+                    {fieldErrors.email}
+                  </p>
+                ) : null}
+              </div>
+              <div>
+                <label htmlFor="password" className={`${c64FormFieldLabelClass} mb-2`}>
                   Password
                 </label>
                 <div className="relative">
-                  <input
+                  <Input
                     id="password"
                     name="password"
                     type={showPassword ? 'text' : 'password'}
-                    required
-                    className="block w-full px-3 py-2 pr-10 border border-border rounded-none shadow-sm placeholder-muted-foreground text-foreground bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary sm:text-sm transition-colors"
+                    autoComplete="current-password"
+                    aria-invalid={fieldErrors.password ? true : undefined}
+                    aria-describedby={fieldErrors.password ? 'sign-in-password-error' : undefined}
+                    className={clsx(c64FormFieldClass, 'pr-10', fieldErrors.password && '!border-[#ee4444]')}
                     placeholder="Enter your password"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => {
+                      setPassword(e.target.value)
+                      setError('')
+                      setFieldErrors((prev) => ({ ...prev, password: undefined }))
+                    }}
                   />
                   <button
                     type="button"
-                    className="absolute inset-y-0 right-0 pr-3 flex items-center text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-inset rounded-r-md"
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center text-[var(--c64-accent)] hover:opacity-80 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--c64-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--c64-border-bg)] rounded-none"
                     onClick={() => setShowPassword(!showPassword)}
                     aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
@@ -139,12 +198,17 @@ export default function SignInPage() {
                     )}
                   </button>
                 </div>
+                {fieldErrors.password ? (
+                  <p id="sign-in-password-error" role="alert" className={c64FieldErrorClass}>
+                    {fieldErrors.password}
+                  </p>
+                ) : null}
               </div>
             </div>
 
             {error && (
-              <div className="rounded-none bg-destructive/10 border border-destructive/20 p-4">
-                <p className="text-sm text-destructive">{error}</p>
+              <div role="alert" className={c64FormErrorBannerClass}>
+                {error}
               </div>
             )}
 

--- a/src/app/admin/guestbook/page.tsx
+++ b/src/app/admin/guestbook/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { TrashIcon, CheckIcon, XMarkIcon, EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 
 interface SocialLinks {
   linkedin?: string
@@ -288,7 +289,7 @@ export default function GuestbookAdmin() {
                     )
                   }}
                 >
-                  {entry.message}
+                  {normalizeLiteralHtmlBreaksInMarkdown(entry.message)}
                 </ReactMarkdown>
               </div>
 

--- a/src/app/api/admin/field-notes/route.ts
+++ b/src/app/api/admin/field-notes/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { sanitizeText, sanitizeMarkdown } from '@/lib/sanitize'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -59,7 +60,7 @@ export async function POST(request: Request) {
     // Sanitize inputs to prevent XSS
     const sanitizedTitle = sanitizeText(title)
     const sanitizedSlug = sanitizeText(slug).toLowerCase().replace(/[^a-z0-9-]/g, '-')
-    const sanitizedContent = sanitizeMarkdown(content)
+    const sanitizedContent = sanitizeMarkdown(normalizeLiteralHtmlBreaksInMarkdown(content))
     const sanitizedImageUrl = sanitizeText(feature_image_url)
     const sanitizedAuthor = sanitizeText(author || 'David Levin')
     const sanitizedOgAlign = ['top', 'center', 'bottom'].includes((og_vertical_align || '').toLowerCase())

--- a/src/app/api/admin/selected-works/route.ts
+++ b/src/app/api/admin/selected-works/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { sanitizeText, sanitizeMarkdown } from '@/lib/sanitize'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -57,7 +58,7 @@ export async function POST(request: Request) {
     // Sanitize inputs to prevent XSS
     const sanitizedTitle = sanitizeText(title)
     const sanitizedSlug = sanitizeText(slug).toLowerCase().replace(/[^a-z0-9-]/g, '-')
-    const sanitizedContent = sanitizeMarkdown(content)
+    const sanitizedContent = sanitizeMarkdown(normalizeLiteralHtmlBreaksInMarkdown(content))
     const sanitizedImageUrl = sanitizeText(feature_image_url)
 
     const { data, error } = await supabase.rpc('prod_upsert_selected_work', {

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
 import { sanitizeMarkdown, sanitizeText, sanitizeUrl } from '@/lib/sanitize'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -50,7 +51,7 @@ export async function POST(request: NextRequest) {
 
     // Sanitize inputs to prevent XSS
     const sanitizedName = sanitizeText(name)
-    const sanitizedMessage = sanitizeMarkdown(message)
+    const sanitizedMessage = sanitizeMarkdown(normalizeLiteralHtmlBreaksInMarkdown(message))
 
     // Validate social links structure and sanitize URLs
     const validSocialLinks = {

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -3,7 +3,6 @@
 import { Button as HeadlessButton } from '@headlessui/react'
 import { forwardRef } from 'react'
 import { clsx } from 'clsx'
-import chroma from 'chroma-js'
 
 export interface ButtonProps {
   children: React.ReactNode
@@ -34,48 +33,21 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     fullWidth = false,
     ...props 
   }, ref) => {
-    // Determine text color for solid buttons based on background contrast
-    // Calculate on each render to react to color changes
-    const getTextColorForSolid = (colorName: string): string => {
-      if (typeof window === 'undefined') return 'text-white'
-      
-      try {
-        // Get the computed CSS variable value
-        const themeRoot =
-          document.getElementById('c64-site-root') ?? document.documentElement
-        const bgColor = getComputedStyle(themeRoot)
-          .getPropertyValue(`--${colorName}`)
-          .trim()
-        
-        if (!bgColor) return 'text-white'
-        
-        const whiteContrast = chroma.contrast(bgColor, '#ffffff')
-        const darkContrast = chroma.contrast(bgColor, '#09090b')
-        
-        // Use dark text if it has better contrast than white
-        return darkContrast > whiteContrast ? 'text-[#09090b]' : 'text-white'
-      } catch {
-        return 'text-white'
-      }
-    }
-    
     const baseStyles = fullWidth 
-      ? 'flex w-full items-center justify-center font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50'
-      : 'inline-flex items-center justify-center font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50'
+      ? 'flex w-full items-center justify-center font-bold tracking-wide transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50'
+      : 'inline-flex items-center justify-center font-bold tracking-wide transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50'
     
-    // Calculate text color for solid buttons only when needed
-    const getTextColorClass = (): string => {
-      if (style !== 'solid') return ''
-      return getTextColorForSolid(color)
-    }
-    
-    // Style variants (visual treatment)
+    // Style variants (visual treatment). Solid text uses theme foreground tokens (SSR-safe).
     const styleVariants = {
       solid: {
-        primary: `bg-primary ${getTextColorClass()} hover:bg-primary/90 focus-visible:outline-primary`,
-        secondary: `bg-secondary ${getTextColorClass()} hover:bg-secondary/90 focus-visible:outline-secondary`,
-        accent: `bg-accent ${getTextColorClass()} hover:bg-accent/90 focus-visible:outline-accent`,
-        destructive: `bg-destructive ${getTextColorClass()} hover:bg-destructive/90 focus-visible:outline-destructive`
+        primary:
+          'bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-primary',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/90 focus-visible:outline-secondary',
+        accent:
+          'bg-accent text-accent-foreground hover:bg-accent/90 focus-visible:outline-accent',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:outline-destructive',
       },
       outline: {
         primary: 'border !border-primary text-primary hover:bg-primary/10 focus-visible:outline-primary dark:brightness-125',
@@ -92,10 +64,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     }
     
     const sizeStyles = {
-      xsmall: 'h-6 px-2 text-xs',
-      small: 'h-8 px-3 text-sm',
-      medium: 'h-10 px-4 text-sm',
-      large: 'h-12 px-6 text-base'
+      xsmall: 'h-6 px-2 text-xs font-semibold tracking-normal',
+      small: 'h-8 px-3 text-sm font-semibold tracking-normal',
+      /** Match C64 form label scale (`text-base` / `sm:text-lg` in guestbook / sign-in). */
+      medium: 'min-h-11 px-4 py-2.5 text-base',
+      large: 'min-h-14 px-6 py-3 text-base sm:text-lg',
     }
     
     return (

--- a/src/app/components/C64AuthenticHomeScreen.tsx
+++ b/src/app/components/C64AuthenticHomeScreen.tsx
@@ -90,16 +90,16 @@ const DISK_SEQUENCE_LINES = [
 const BOOT_LINE_BANNER = '**** LEVINMEDIA 64 BASIC V2 ****'
 
 /** ms after each ROM line before the next (banner → blank → RAM). */
-const ROM_PAUSE_MS_AFTER_LINE: number[] = [220, 200, 360]
+const ROM_PAUSE_MS_AFTER_LINE: number[] = [110, 100, 180]
 
 /** ms between each revealed character while typing disk lines (left → right). */
-const DISK_TYPE_MS = 42
+const DISK_TYPE_MS = 21
 
 /** ms after an empty disk line before continuing. */
-const DISK_BLANK_LINE_PAUSE_MS = 200
+const DISK_BLANK_LINE_PAUSE_MS = 100
 
-/** After “LOADING” is typed: square cursor becomes ASCII spinner; total hold = 12×125ms = 1500ms. */
-const DISK_SPIN_FRAME_MS = 125
+/** After “LOADING” is typed: square cursor becomes ASCII spinner; total hold = 12×62ms ≈ 744ms. */
+const DISK_SPIN_FRAME_MS = 62
 const DISK_SPIN_FRAME_COUNT = 12
 
 const DISK_SPIN_CHARS = ['|', '/', '-', '\\'] as const
@@ -108,13 +108,13 @@ const DISK_SPIN_CHARS = ['|', '/', '-', '\\'] as const
  * ms after a disk line is fully typed (and spinner done, if any), before the next line starts.
  */
 const DISK_PAUSE_AFTER_LINE_MS: number[] = [
-  340,
-  400,
-  260,
-  420,
-  280,
-  360,
-  360,
+  170,
+  200,
+  130,
+  210,
+  140,
+  180,
+  180,
 ]
 
 const BOOT_LINE_RAM = '64K RAM SYSTEM  38911 BASIC BYTES FREE'
@@ -272,19 +272,19 @@ function TerminalDiskCatalogEmbed({
   )
 }
 
-const LOAD_TYPEWRITER_MS = 42
-const LOAD_AFTER_TYPED_PAUSE_MS = 140
+const LOAD_TYPEWRITER_MS = 21
+const LOAD_AFTER_TYPED_PAUSE_MS = 70
 
 /** Terminal load sequence after a valid LOAD line (matches C64 disk behavior). */
-const TERMINAL_LOAD_BLANK_PAUSE_MS = 200
-const TERMINAL_LOAD_AFTER_BLANK_MS = 280
-const TERMINAL_LOAD_AFTER_SEARCHING_MS = 380
-/** Same cadence as boot disk LOADING spinner (12×125ms ≈ 1.5s). */
+const TERMINAL_LOAD_BLANK_PAUSE_MS = 100
+const TERMINAL_LOAD_AFTER_BLANK_MS = 140
+const TERMINAL_LOAD_AFTER_SEARCHING_MS = 190
+/** Same cadence as boot disk LOADING spinner (12×62ms ≈ 744ms). */
 const TERMINAL_LOAD_SPIN_FRAME_MS = DISK_SPIN_FRAME_MS
 const TERMINAL_LOAD_SPIN_FRAME_COUNT = DISK_SPIN_FRAME_COUNT
 const TERMINAL_LOAD_SPIN_CHARS = DISK_SPIN_CHARS
 /** After READY. on click path: brief beat before RUN + open. */
-const TERMINAL_AUTO_RUN_PAUSE_MS = 120
+const TERMINAL_AUTO_RUN_PAUSE_MS = 60
 
 function isAnySiteDrawerOpen(searchParams: ReturnType<typeof useSearchParams>): boolean {
   return (
@@ -465,7 +465,7 @@ export default function C64AuthenticHomeScreen({
     }
     const id = window.setTimeout(() => {
       focusC64TerminalInput(terminalInputRef)
-    }, 80)
+    }, 40)
     return () => window.clearTimeout(id)
   }, [bootComplete])
 
@@ -494,7 +494,7 @@ export default function C64AuthenticHomeScreen({
           return
         }
         playDiskListReplayRef.current()
-      }, 200)
+      }, 100)
       return () => window.clearTimeout(id)
     }
     return undefined
@@ -1237,7 +1237,7 @@ export default function C64AuthenticHomeScreen({
                   setDiskCompletedLines((prev) => [...prev, text])
                   setDiskTyping(null)
                   const pauseAfter =
-                    DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 320
+                    DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 160
                   after(pauseAfter, () => runDiskLine(lineIndex + 1))
                 }
               }
@@ -1247,7 +1247,7 @@ export default function C64AuthenticHomeScreen({
             setDiskCompletedLines((prev) => [...prev, text])
             setDiskTyping(null)
             const pauseAfter =
-              DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 320
+              DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 160
             if (lineIndex < DISK_SEQUENCE_LINES.length - 1) {
               after(pauseAfter, () => runDiskLine(lineIndex + 1))
             } else {
@@ -1261,11 +1261,11 @@ export default function C64AuthenticHomeScreen({
     }
 
     setLinesShown(1)
-    after(ROM_PAUSE_MS_AFTER_LINE[0] ?? 220, () => {
+    after(ROM_PAUSE_MS_AFTER_LINE[0] ?? 110, () => {
       setLinesShown(2)
-      after(ROM_PAUSE_MS_AFTER_LINE[1] ?? 200, () => {
+      after(ROM_PAUSE_MS_AFTER_LINE[1] ?? 100, () => {
         setLinesShown(3)
-        after(ROM_PAUSE_MS_AFTER_LINE[2] ?? 360, () => runDiskLine(0))
+        after(ROM_PAUSE_MS_AFTER_LINE[2] ?? 180, () => runDiskLine(0))
       })
     })
 
@@ -1395,7 +1395,7 @@ export default function C64AuthenticHomeScreen({
                   setDiskCompletedLines((prev) => [...prev, text])
                   setDiskTyping(null)
                   const pauseAfter =
-                    DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 320
+                    DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 160
                   after(pauseAfter, () => runDiskLine(lineIndex + 1))
                 }
               }
@@ -1405,7 +1405,7 @@ export default function C64AuthenticHomeScreen({
             setDiskCompletedLines((prev) => [...prev, text])
             setDiskTyping(null)
             const pauseAfter =
-              DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 320
+              DISK_PAUSE_AFTER_LINE_MS[lineIndex] ?? 160
             if (lineIndex < DISK_SEQUENCE_LINES.length - 1) {
               after(pauseAfter, () => runDiskLine(lineIndex + 1))
             } else {
@@ -1419,11 +1419,11 @@ export default function C64AuthenticHomeScreen({
     }
 
     setLinesShown(1)
-    after(ROM_PAUSE_MS_AFTER_LINE[0] ?? 220, () => {
+    after(ROM_PAUSE_MS_AFTER_LINE[0] ?? 110, () => {
       setLinesShown(2)
-      after(ROM_PAUSE_MS_AFTER_LINE[1] ?? 200, () => {
+      after(ROM_PAUSE_MS_AFTER_LINE[1] ?? 100, () => {
         setLinesShown(3)
-        after(ROM_PAUSE_MS_AFTER_LINE[2] ?? 360, () => runDiskLine(0))
+        after(ROM_PAUSE_MS_AFTER_LINE[2] ?? 180, () => runDiskLine(0))
       })
     })
 

--- a/src/app/components/CrepeEditor.tsx
+++ b/src/app/components/CrepeEditor.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 
 interface CrepeEditorProps {
   value: string
@@ -98,7 +99,7 @@ export default function CrepeEditor({ value, onChange, placeholder, className }:
       {showPreview ? (
         <div className="p-3 min-h-[200px] prose prose-sm max-w-none dark:prose-invert">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>
-            {value || '*Nothing to preview yet...*'}
+            {normalizeLiteralHtmlBreaksInMarkdown(value || '*Nothing to preview yet...*')}
           </ReactMarkdown>
         </div>
       ) : (

--- a/src/app/components/FieldNoteDetail.tsx
+++ b/src/app/components/FieldNoteDetail.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 import VideoPlayer from './VideoPlayer'
 
 interface FieldNoteDetailProps {
@@ -148,10 +149,13 @@ export default function FieldNoteDetail({ slug, onTitleLoad, onTitleVisibilityCh
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
         <div className="absolute bottom-0 left-0 right-0 p-8">
-          <h1 ref={titleRef} className="text-4xl font-bold text-white font-[family-name:var(--font-geist-mono)]">
+          <h1
+            ref={titleRef}
+            className="text-4xl font-bold font-[family-name:var(--font-geist-mono)] text-[#ffffff] [text-shadow:0_2px_12px_rgba(0,0,0,0.9)]"
+          >
             {note.title}
           </h1>
-          <p className="text-white/80 mt-2 font-[family-name:var(--font-geist-mono)]">
+          <p className="text-[#ffffff] mt-2 font-[family-name:var(--font-geist-mono)] [text-shadow:0_1px_8px_rgba(0,0,0,0.85)]">
             {note.author}
           </p>
         </div>
@@ -173,12 +177,24 @@ export default function FieldNoteDetail({ slug, onTitleLoad, onTitleVisibilityCh
                 <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 components={{
-                    h1: ({ children }) => <h1 className="text-3xl font-bold text-foreground mb-4 mt-6 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h1>,
-                    h2: ({ children }) => <h2 className="text-2xl font-bold mb-3 mt-5 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--accent)' }}>{children}</h2>,
-                    h3: ({ children }) => <h3 className="text-xl font-semibold mb-3 mt-4 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--secondary)' }}>{children}</h3>,
-                    h4: ({ children }) => <h4 className="text-lg font-semibold text-foreground mb-2 mt-3 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h4>,
-                    h5: ({ children }) => <h5 className="text-base font-semibold text-foreground mb-2 mt-3 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h5>,
-                    h6: ({ children }) => <h6 className="text-sm font-semibold text-foreground mb-2 mt-2 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h6>,
+                    h1: ({ children }) => (
+                      <h1 className="text-3xl font-bold text-[#ffffff] mb-4 mt-6 font-[family-name:var(--font-geist-mono)]">{children}</h1>
+                    ),
+                    h2: ({ children }) => (
+                      <h2 className="text-2xl font-bold text-[#ffffff] mb-3 mt-5 font-[family-name:var(--font-geist-mono)]">{children}</h2>
+                    ),
+                    h3: ({ children }) => (
+                      <h3 className="text-xl font-semibold uppercase tracking-wide text-[#ffffff] mb-3 mt-4 font-[family-name:var(--font-geist-mono)]">{children}</h3>
+                    ),
+                    h4: ({ children }) => (
+                      <h4 className="text-lg font-semibold text-[#ffffff] mb-2 mt-3 font-[family-name:var(--font-geist-mono)]">{children}</h4>
+                    ),
+                    h5: ({ children }) => (
+                      <h5 className="text-base font-semibold text-[#ffffff] mb-2 mt-3 font-[family-name:var(--font-geist-mono)]">{children}</h5>
+                    ),
+                    h6: ({ children }) => (
+                      <h6 className="text-sm font-semibold text-[#ffffff] mb-2 mt-2 font-[family-name:var(--font-geist-mono)]">{children}</h6>
+                    ),
                     p: ({ children, node }) => {
                       // Check if this paragraph only contains an image
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -225,7 +241,7 @@ export default function FieldNoteDetail({ slug, onTitleLoad, onTitleVisibilityCh
                     )
                   }}
                 >
-                  {part.content}
+                  {normalizeLiteralHtmlBreaksInMarkdown(part.content)}
                 </ReactMarkdown>
               </div>
             )

--- a/src/app/components/FieldNotesContent.tsx
+++ b/src/app/components/FieldNotesContent.tsx
@@ -88,7 +88,7 @@ const FieldNotesContent: React.FC = () => {
                 }}
               />
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                <h3 className="text-white text-sm font-medium font-[family-name:var(--font-geist-mono)] text-center px-2 bg-black/50 rounded-sm">
+                <h3 className="text-center px-2 py-1.5 font-[family-name:var(--font-geist-mono)] text-base sm:text-lg font-bold leading-tight text-[#ffffff] bg-black/70 [text-shadow:0_1px_3px_rgba(0,0,0,0.95)] rounded-sm">
                   {note.title}
                 </h3>
               </div>

--- a/src/app/components/Guestbook.tsx
+++ b/src/app/components/Guestbook.tsx
@@ -4,9 +4,11 @@ import { useState, useEffect } from 'react'
 import { PaperAirplaneIcon, UserIcon, PencilSquareIcon } from '@heroicons/react/24/outline'
 import { Input } from '@headlessui/react'
 import ReactMarkdown from 'react-markdown'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 import remarkGfm from 'remark-gfm'
 import MilkdownEditor from './MilkdownEditor'
 import Button from './Button'
+import { c64FormFieldClass, c64FormFieldLabelClass } from '@/lib/c64-form-classes'
 
 interface SocialLinks {
   linkedin?: string
@@ -32,8 +34,8 @@ interface GuestbookFormData {
 const boxClass =
   'border-4 border-[var(--c64-accent)] bg-[var(--c64-screen-bg)] c64-petscii-frame c64-screen-grid'
 
-const fieldClass =
-  'block w-full px-3 py-2 border-2 border-[var(--c64-accent)]/45 bg-[var(--c64-border-bg)]/25 text-foreground placeholder:text-foreground/45 shadow-none focus:outline-none focus:ring-2 focus:ring-[var(--c64-accent)] focus:border-[var(--c64-accent)] sm:text-sm transition-colors rounded-none'
+const fieldClass = c64FormFieldClass
+const guestbookFieldLabelClass = c64FormFieldLabelClass
 
 export default function Guestbook() {
   const [entries, setEntries] = useState<GuestbookEntry[]>([])
@@ -180,7 +182,7 @@ export default function Guestbook() {
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Name Field */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
+            <label className={`${guestbookFieldLabelClass} mb-2`}>
               Your Name
             </label>
             <Input
@@ -196,7 +198,7 @@ export default function Guestbook() {
 
           {/* Message Field */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
+            <label className={`${guestbookFieldLabelClass} mb-2`}>
               Your Message
             </label>
             <div className="relative gb-editor">
@@ -212,13 +214,13 @@ export default function Guestbook() {
 
           {/* Social Links */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-3">
+            <label className={`${guestbookFieldLabelClass} mb-3`}>
               Your Social Links (Optional)
             </label>
             <div className="grid grid-cols-2 gap-4">
               {['linkedin', 'threads', 'twitter', 'instagram'].map((platform) => (
                 <div key={platform}>
-                  <label className="block text-xs text-muted-foreground mb-1 capitalize">
+                  <label className={`${guestbookFieldLabelClass} mb-1.5 capitalize`}>
                     {getSocialIcon(platform)} {platform}
                   </label>
                   <Input
@@ -362,7 +364,7 @@ export default function Guestbook() {
                     )
                   }}
                 >
-                  {entry.message}
+                  {normalizeLiteralHtmlBreaksInMarkdown(entry.message)}
                 </ReactMarkdown>
               </div>
 

--- a/src/app/components/SelectedWorkDetail.tsx
+++ b/src/app/components/SelectedWorkDetail.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { normalizeLiteralHtmlBreaksInMarkdown } from '@/lib/markdown-normalize'
 import VideoPlayer from './VideoPlayer'
 
 interface SelectedWorkDetailProps {
@@ -146,7 +147,10 @@ export default function SelectedWorkDetail({ slug, onTitleLoad, onTitleVisibilit
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
         <div className="absolute bottom-0 left-0 right-0 p-8">
-          <h1 ref={titleRef} className="text-4xl font-bold text-white font-[family-name:var(--font-geist-mono)]">
+          <h1
+            ref={titleRef}
+            className="text-4xl font-bold font-[family-name:var(--font-geist-mono)] text-[#ffffff] [text-shadow:0_2px_12px_rgba(0,0,0,0.9)]"
+          >
             {work.title}
           </h1>
         </div>
@@ -168,12 +172,24 @@ export default function SelectedWorkDetail({ slug, onTitleLoad, onTitleVisibilit
                 <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 components={{
-                    h1: ({ children }) => <h1 className="text-3xl font-bold text-foreground mb-4 mt-6 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h1>,
-                    h2: ({ children }) => <h2 className="text-2xl font-bold mb-3 mt-5 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--accent)' }}>{children}</h2>,
-                    h3: ({ children }) => <h3 className="text-xl font-semibold mb-3 mt-4 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--secondary)' }}>{children}</h3>,
-                    h4: ({ children }) => <h4 className="text-lg font-semibold text-foreground mb-2 mt-3 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h4>,
-                    h5: ({ children }) => <h5 className="text-base font-semibold text-foreground mb-2 mt-3 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h5>,
-                    h6: ({ children }) => <h6 className="text-sm font-semibold text-foreground mb-2 mt-2 font-[family-name:var(--font-geist-mono)]" style={{ color: 'var(--foreground)' }}>{children}</h6>,
+                    h1: ({ children }) => (
+                      <h1 className="text-3xl font-bold text-[#ffffff] mb-4 mt-6 font-[family-name:var(--font-geist-mono)]">{children}</h1>
+                    ),
+                    h2: ({ children }) => (
+                      <h2 className="text-2xl font-bold text-[#ffffff] mb-3 mt-5 font-[family-name:var(--font-geist-mono)]">{children}</h2>
+                    ),
+                    h3: ({ children }) => (
+                      <h3 className="text-xl font-semibold uppercase tracking-wide text-[#ffffff] mb-3 mt-4 font-[family-name:var(--font-geist-mono)]">{children}</h3>
+                    ),
+                    h4: ({ children }) => (
+                      <h4 className="text-lg font-semibold text-[#ffffff] mb-2 mt-3 font-[family-name:var(--font-geist-mono)]">{children}</h4>
+                    ),
+                    h5: ({ children }) => (
+                      <h5 className="text-base font-semibold text-[#ffffff] mb-2 mt-3 font-[family-name:var(--font-geist-mono)]">{children}</h5>
+                    ),
+                    h6: ({ children }) => (
+                      <h6 className="text-sm font-semibold text-[#ffffff] mb-2 mt-2 font-[family-name:var(--font-geist-mono)]">{children}</h6>
+                    ),
                     p: ({ children, node }) => {
                       // Check if this paragraph only contains an image
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -220,7 +236,7 @@ export default function SelectedWorkDetail({ slug, onTitleLoad, onTitleVisibilit
                     )
                   }}
                 >
-                  {part.content}
+                  {normalizeLiteralHtmlBreaksInMarkdown(part.content)}
                 </ReactMarkdown>
               </div>
             )

--- a/src/app/components/SelectedWorksContent.tsx
+++ b/src/app/components/SelectedWorksContent.tsx
@@ -92,7 +92,7 @@ const SelectedWorksContent: React.FC<SelectedWorksContentProps> = ({ initialWork
                 }}
               />
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                <h3 className="text-white text-sm font-medium font-[family-name:var(--font-geist-mono)] text-center px-2 bg-black/50 rounded-sm">
+                <h3 className="text-center px-2 py-1.5 font-[family-name:var(--font-geist-mono)] text-base sm:text-lg font-bold leading-tight text-[#ffffff] bg-black/70 [text-shadow:0_1px_3px_rgba(0,0,0,0.95)] rounded-sm">
                   {work.title}
                 </h3>
               </div>

--- a/src/app/components/SiteSettingsContent.tsx
+++ b/src/app/components/SiteSettingsContent.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline'
-import Button from './Button'
 import {
   defaultC64Settings,
   LEGACY_SITE_THEME_KEY,
@@ -13,7 +12,6 @@ import {
   type C64BootMode,
   type C64ScreenTint,
   type C64Settings,
-  type C64TextScale,
 } from '@/lib/c64-settings'
 import {
   applyC64SettingsNow,
@@ -25,8 +23,8 @@ const ACCENT_OPTIONS: { id: C64Accent; label: string }[] = [
   { id: 'yellow', label: 'Yellow' },
   { id: 'green', label: 'Green' },
   { id: 'pink', label: 'Pink' },
-  { id: 'orange', label: 'Orange' },
-  { id: 'white', label: 'White' },
+  { id: 'orange', label: 'Dirt' },
+  { id: 'white', label: 'Abyss' },
   { id: 'red', label: 'Red' },
 ]
 
@@ -40,11 +38,6 @@ const BOOT_OPTIONS: { id: C64BootMode; label: string; hint: string }[] = [
   { id: 'off', label: 'Off', hint: 'Home shows the classic boot text immediately (no type-in)' },
   { id: 'session', label: 'Once per tab', hint: 'Type-in animation once; then instant until you close this tab' },
   { id: 'always', label: 'Always animate', hint: 'Type-in lines every time the home page loads' },
-]
-
-const TEXT_OPTIONS: { id: C64TextScale; label: string }[] = [
-  { id: 'compact', label: 'Compact' },
-  { id: 'comfortable', label: 'Comfortable' },
 ]
 
 export default function SiteSettingsContent() {
@@ -106,7 +99,7 @@ export default function SiteSettingsContent() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 c64-site-settings">
       <section className="border-2 border-primary bg-background p-4 c64-screen-grid">
         <h3 className="text-lg font-bold text-foreground mb-3 border-b-2 border-primary pb-2">
           Highlight color
@@ -157,28 +150,6 @@ export default function SiteSettingsContent() {
 
       <section className="border-2 border-primary bg-background p-4 c64-screen-grid">
         <h3 className="text-lg font-bold text-foreground mb-3 border-b-2 border-primary pb-2">
-          Text size
-        </h3>
-        <div className="flex flex-wrap gap-2">
-          {TEXT_OPTIONS.map(({ id, label }) => (
-            <button
-              key={id}
-              type="button"
-              onClick={() => persist({ ...settings, textScale: id })}
-              className={`min-h-11 px-4 py-2 border-2 text-sm font-bold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${
-                settings.textScale === id
-                  ? 'border-primary bg-primary/20'
-                  : 'border-border hover:bg-muted'
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </section>
-
-      <section className="border-2 border-primary bg-background p-4 c64-screen-grid">
-        <h3 className="text-lg font-bold text-foreground mb-3 border-b-2 border-primary pb-2">
           Effects
         </h3>
         <label className="flex items-center gap-3 min-h-11 cursor-pointer">
@@ -186,7 +157,7 @@ export default function SiteSettingsContent() {
             type="checkbox"
             checked={settings.scanlines}
             onChange={(e) => persist({ ...settings, scanlines: e.target.checked })}
-            className="h-5 w-5 border-2 border-primary accent-primary"
+            className="h-5 w-5 shrink-0"
           />
           <span className="text-foreground">CRT scanlines overlay</span>
         </label>
@@ -207,7 +178,7 @@ export default function SiteSettingsContent() {
                 name="c64-boot"
                 checked={settings.boot === id}
                 onChange={() => persist({ ...settings, boot: id })}
-                className="mt-1 h-4 w-4 border-2 border-primary accent-primary"
+                className="mt-1 h-4 w-4 shrink-0"
               />
               <span>
                 <span className="block font-bold text-foreground">{label}</span>
@@ -215,23 +186,6 @@ export default function SiteSettingsContent() {
               </span>
             </label>
           ))}
-        </div>
-      </section>
-
-      <section className="border-2 border-primary bg-background p-4 c64-screen-grid">
-        <h3 className="text-lg font-bold text-foreground mb-3 border-b-2 border-primary pb-2">
-          Preview
-        </h3>
-        <div className="flex flex-wrap gap-2">
-          <Button style="solid" color="primary" size="small">
-            Primary
-          </Button>
-          <Button style="outline" color="accent" size="small">
-            Outline
-          </Button>
-          <Button style="ghost" color="primary" size="small">
-            Ghost
-          </Button>
         </div>
       </section>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1006,6 +1006,45 @@ body > div[style*="position: fixed"] * {
   line-height: 1.55;
 }
 
+/* Site settings: checkbox / radio use accent wireframe when off (native OS fill reads gray on dark C64 UI). */
+.c64-site-settings input[type="checkbox"],
+.c64-site-settings input[type="radio"] {
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  border: 2px solid var(--c64-accent, var(--primary));
+  background-color: transparent;
+}
+
+.c64-site-settings input[type="checkbox"] {
+  border-radius: 0;
+}
+
+.c64-site-settings input[type="radio"] {
+  border-radius: 50%;
+}
+
+.c64-site-settings input[type="checkbox"]:checked {
+  background-color: var(--c64-accent, var(--primary));
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3E%3Cpath d='M3.5 8 6.5 11 12.5 4' stroke='%23181818' stroke-width='2' stroke-linecap='square' stroke-linejoin='miter'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 68%;
+}
+
+.c64-site-settings input[type="radio"]:checked {
+  background-color: var(--c64-accent, var(--primary));
+  box-shadow: inset 0 0 0 2px var(--c64-screen-bg, var(--background));
+}
+
+.c64-site-settings input[type="checkbox"]:focus-visible,
+.c64-site-settings input[type="radio"]:focus-visible {
+  outline: 2px solid var(--c64-accent, var(--primary));
+  outline-offset: 2px;
+}
+
 /* Drawer body copy: one size (~20px) across About, work history, works, notes, guestbook. */
 #c64-site-root .c64-drawer-copy {
   font-size: 20px;

--- a/src/lib/c64-form-classes.ts
+++ b/src/lib/c64-form-classes.ts
@@ -1,0 +1,6 @@
+/** Shared C64 drawer form chrome (guestbook, sign-in, etc.). */
+export const c64FormFieldClass =
+  'block w-full px-3 py-2 border-2 border-[var(--c64-accent)]/45 bg-[var(--c64-border-bg)]/25 text-foreground placeholder:text-foreground/45 shadow-none focus:outline-none focus:ring-2 focus:ring-[var(--c64-accent)] focus:border-[var(--c64-accent)] sm:text-sm transition-colors rounded-none'
+
+export const c64FormFieldLabelClass =
+  'block text-base sm:text-lg font-bold tracking-wide text-[var(--c64-accent)]'

--- a/src/lib/c64-settings.ts
+++ b/src/lib/c64-settings.ts
@@ -45,7 +45,7 @@ export interface C64Settings {
 export const defaultC64Settings: C64Settings = {
   accent: 'classic',
   screenTint: 'default',
-  scanlines: true,
+  scanlines: false,
   boot: 'session',
   textScale: 'comfortable',
 }
@@ -204,12 +204,18 @@ export function getC64ThemeColors(
   return { screen, border, crtInk }
 }
 
-function onAccentForeground(accentHex: string): string {
-  const lum = chroma(accentHex).luminance()
-  if (lum > 0.52) {
-    return chroma.mix('#080510', accentHex, 0.12).hex()
+/**
+ * Pick white vs near-black for text/icons on a solid `bgHex` so contrast stays strong across
+ * every C64 accent (pastels included). Uses WCAG contrast ratio from chroma-js.
+ */
+function pickHighContrastForeground(bgHex: string): string {
+  try {
+    const onWhite = chroma.contrast(bgHex, '#ffffff')
+    const onDark = chroma.contrast(bgHex, '#0a0a12')
+    return onWhite >= onDark ? '#ffffff' : '#0a0a12'
+  } catch {
+    return '#0a0a12'
   }
-  return chroma.mix('#f8f8ff', accentHex, 0.08).hex()
 }
 
 function buildCssVarSnapshot(
@@ -224,11 +230,8 @@ function buildCssVarSnapshot(
       : chroma.mix(crtInk, '#ffffff', 0.1).hex()
   const mutedFg = chroma.mix(screen, crtInk, 0.52).hex()
   const secondary = chroma.mix(screen, accentHex, 0.4).hex()
-  const secondaryFg =
-    accent === 'white'
-      ? chroma.mix(accentHex, crtInk, 0.28).hex()
-      : chroma.mix(accentHex, '#ffffff', 0.32).hex()
-  const onPrimary = onAccentForeground(accentHex)
+  const onPrimary = pickHighContrastForeground(accentHex)
+  const secondaryFg = pickHighContrastForeground(secondary)
 
   return {
     '--c64-screen-bg': screen,
@@ -249,7 +252,7 @@ function buildCssVarSnapshot(
     '--accent': accentHex,
     '--accent-foreground': onPrimary,
     '--destructive': '#ee4444',
-    '--destructive-foreground': '#ffffff',
+    '--destructive-foreground': pickHighContrastForeground('#ee4444'),
     '--ring': accentHex,
   }
 }
@@ -277,7 +280,8 @@ const TEXT_SCALE: Record<C64TextScale, string> = {
 
 export function saveC64Settings(settings: C64Settings): void {
   if (typeof window === 'undefined') return
-  localStorage.setItem(C64_STORAGE_KEY, JSON.stringify(settings))
+  const toSave: C64Settings = { ...settings, textScale: 'comfortable' }
+  localStorage.setItem(C64_STORAGE_KEY, JSON.stringify(toSave))
 }
 
 export function loadC64Settings(): C64Settings {
@@ -290,6 +294,7 @@ export function loadC64Settings(): C64Settings {
       if (String(merged.accent) === 'cyan' || String(merged.accent) === 'lightblue') {
         merged.accent = 'classic'
       }
+      merged.textScale = 'comfortable'
       return merged
     }
     const legacy = localStorage.getItem(LEGACY_SITE_THEME_KEY)
@@ -324,7 +329,7 @@ export function applyC64ToElement(el: HTMLElement, s: C64Settings): void {
   for (const [k, v] of Object.entries(snap)) {
     el.style.setProperty(k, v)
   }
-  el.style.setProperty('--c64-text-scale', TEXT_SCALE[s.textScale])
+  el.style.setProperty('--c64-text-scale', TEXT_SCALE.comfortable)
 
   el.dataset.c64Scanlines = s.scanlines ? 'on' : 'off'
   el.dataset.c64Boot = s.boot

--- a/src/lib/markdown-normalize.ts
+++ b/src/lib/markdown-normalize.ts
@@ -1,0 +1,25 @@
+/**
+ * Crepe/Milkdown may emit literal `<br>` (or `<br />`) inside markdown strings.
+ * react-markdown does not parse that as HTML by default, so the tag text can appear in the UI.
+ * Replace those tags with newlines so the markdown parser produces normal breaks.
+ * Fenced code blocks are left unchanged so examples mentioning `<br>` stay intact.
+ */
+export function normalizeLiteralHtmlBreaksInMarkdown(source: string): string {
+  if (!source || !/<br\b/i.test(source)) return source
+
+  const fence = /```[\s\S]*?```|~~~[\s\S]*?~~~/g
+  const chunks: string[] = []
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = fence.exec(source)) !== null) {
+    chunks.push(replaceBrTags(source.slice(last, m.index)))
+    chunks.push(m[0])
+    last = m.index + m[0].length
+  }
+  chunks.push(replaceBrTags(source.slice(last)))
+  return chunks.join('')
+}
+
+function replaceBrTags(s: string): string {
+  return s.replace(/<br\b[^>]*>/gi, '\n')
+}


### PR DESCRIPTION
- Faster C64 boot/typewriter timings; scanlines off by default
- Site settings: remove text size & preview; Dirt/Abyss labels; themed form controls
- Markdown: strip literal br tags; featured works & field notes typography
- Guestbook & sign-in: shared C64 field styles; custom validation; hydration-safe Button
- C64 theme: WCAG foreground pick for primary/secondary buttons; larger button type