### PR TITLE
feat(admin): direct Supabase video uploads and web playback guidance

### DIFF
--- a/src/app/api/admin/upload-video/init/route.ts
+++ b/src/app/api/admin/upload-video/init/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthCookiePayload, hasPrivateAccess } from '@/lib/auth-cookie'
+import {
+  ADMIN_VIDEO_MAX_BYTES,
+  isAllowedVideoMime,
+  safeVideoExtension,
+  sanitizeVideoUploadFolder,
+} from '@/lib/admin-video-upload'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+)
+
+/**
+ * Returns a signed-upload token so the browser can upload large videos directly to Supabase
+ * (bypasses Vercel / Next.js request body limits).
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getAuthCookiePayload()
+    if (!auth || !hasPrivateAccess(auth.access_role)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = (await request.json()) as {
+      folder?: string
+      fileName?: string
+      contentType?: string
+      fileSize?: number
+    }
+
+    const contentType = typeof body.contentType === 'string' ? body.contentType.trim() : ''
+    const fileName = typeof body.fileName === 'string' ? body.fileName : 'video'
+    const fileSize = typeof body.fileSize === 'number' ? body.fileSize : 0
+
+    if (!contentType || !isAllowedVideoMime(contentType)) {
+      return NextResponse.json({ error: 'Invalid or missing video content type.' }, { status: 400 })
+    }
+
+    if (fileSize > 0 && fileSize > ADMIN_VIDEO_MAX_BYTES) {
+      return NextResponse.json(
+        { error: `Video must be under ${Math.floor(ADMIN_VIDEO_MAX_BYTES / (1024 * 1024))} MB.` },
+        { status: 400 },
+      )
+    }
+
+    const ext = safeVideoExtension(contentType, fileName)
+    if (!ext) {
+      return NextResponse.json({ error: 'Could not determine a safe file extension.' }, { status: 400 })
+    }
+
+    const folder = sanitizeVideoUploadFolder(body.folder)
+    const objectPath = `${folder}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
+
+    const { data, error } = await supabase.storage.from('media').createSignedUploadUrl(objectPath, {
+      upsert: false,
+    })
+
+    if (error || !data) {
+      console.error('createSignedUploadUrl:', error)
+      return NextResponse.json({ error: error?.message ?? 'Could not create upload URL.' }, { status: 500 })
+    }
+
+    const { data: urlData } = supabase.storage.from('media').getPublicUrl(objectPath)
+
+    return NextResponse.json({
+      path: data.path,
+      token: data.token,
+      publicUrl: urlData.publicUrl,
+    })
+  } catch (e) {
+    console.error('upload-video/init:', e)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/upload-video/route.ts
+++ b/src/app/api/admin/upload-video/route.ts
@@ -1,80 +1,88 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { isAllowedVideoMime, sanitizeVideoUploadFolder } from '@/lib/admin-video-upload'
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 )
 
+/** Reject large bodies before buffering — large uploads must use POST /api/admin/upload-video/init + client upload. */
+const MAX_INLINE_BYTES = 8 * 1024 * 1024
+
+/**
+ * Legacy path: small videos only (full body goes through this server).
+ * Prefer `/api/admin/upload-video/init` + browser `uploadToSignedUrl` for files over a few MB.
+ */
 export async function POST(request: NextRequest) {
   try {
+    const len = request.headers.get('content-length')
+    if (len) {
+      const n = parseInt(len, 10)
+      if (!Number.isNaN(n) && n > MAX_INLINE_BYTES) {
+        return NextResponse.json(
+          {
+            error:
+              'This upload is too large for the legacy endpoint. Refresh the editor page, then upload again (large files go directly to storage).',
+            code: 'USE_SIGNED_UPLOAD',
+          },
+          { status: 413 },
+        )
+      }
+    }
+
     const formData = await request.formData()
     const file = formData.get('file') as File
-    const folder = formData.get('folder') as string || 'selected-works-videos'
+    const folder = sanitizeVideoUploadFolder(formData.get('folder') as string)
 
     if (!file) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 })
     }
 
-    // Validate file type - accept common video formats
-    const validVideoTypes = [
-      'video/mp4',
-      'video/webm',
-      'video/ogg',
-      'video/quicktime', // .mov
-      'video/x-msvideo', // .avi
-      'video/x-matroska', // .mkv
-      'video/mpeg',
-      'video/3gpp',
-      'video/x-flv',
-    ]
+    if (!isAllowedVideoMime(file.type)) {
+      return NextResponse.json({ error: 'Invalid file type. Please upload a video file.' }, { status: 400 })
+    }
 
-    if (!validVideoTypes.includes(file.type)) {
+    if (file.size > MAX_INLINE_BYTES) {
       return NextResponse.json(
-        { error: 'Invalid file type. Please upload a video file.' },
-        { status: 400 }
+        {
+          error: 'File too large. Refresh the page and use the updated uploader.',
+          code: 'USE_SIGNED_UPLOAD',
+        },
+        { status: 413 },
       )
     }
 
-    // Generate unique filename
     const fileExt = file.name.split('.').pop()
     const fileName = `${Date.now()}-${Math.random().toString(36).substring(2)}.${fileExt}`
     const filePath = `${folder}/${fileName}`
 
-    // Convert file to buffer
     const bytes = await file.arrayBuffer()
     const buffer = Buffer.from(bytes)
 
-    console.log(`📹 Uploading video: ${file.name} (${(file.size / 1024 / 1024).toFixed(2)}MB)`)
+    console.log(`📹 (inline) Uploading video: ${file.name} (${(file.size / 1024 / 1024).toFixed(2)}MB)`)
 
-    // Upload to Supabase storage
-    const { error } = await supabase.storage
-      .from('media')
-      .upload(filePath, buffer, {
-        contentType: file.type,
-        cacheControl: '3600',
-        upsert: false
-      })
+    const { error } = await supabase.storage.from('media').upload(filePath, buffer, {
+      contentType: file.type,
+      cacheControl: '3600',
+      upsert: false,
+    })
 
     if (error) {
       console.error('Error uploading video:', error)
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
-    // Get public URL
-    const { data: urlData } = supabase.storage
-      .from('media')
-      .getPublicUrl(filePath)
+    const { data: urlData } = supabase.storage.from('media').getPublicUrl(filePath)
 
     console.log(`✅ Video uploaded successfully: ${urlData.publicUrl}`)
 
-    return NextResponse.json({ 
+    return NextResponse.json({
       url: urlData.publicUrl,
-      path: filePath
+      path: filePath,
     })
   } catch (error) {
     console.error('Error in video upload API:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }
-

--- a/src/app/components/MilkdownEditor.tsx
+++ b/src/app/components/MilkdownEditor.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { createClient } from '@supabase/supabase-js'
 import { Crepe } from '@milkdown/crepe'
+import { ADMIN_VIDEO_MAX_BYTES } from '@/lib/admin-video-upload'
 import '@milkdown/crepe/theme/common/style.css'
 // Don't import frame.css - we'll use our own theme
 
@@ -29,30 +31,80 @@ export default function MilkdownEditor({ value, onChange, className, allowVideo 
   const handleVideoUpload = async (file: File) => {
     setIsUploadingVideo(true)
     try {
-      const formData = new FormData()
-      formData.append('file', file)
-      formData.append('folder', 'selected-works-videos')
-
-      console.log('📹 Uploading video:', file.name, 'Size:', (file.size / 1024 / 1024).toFixed(2), 'MB')
-
-      const response = await fetch('/api/admin/upload-video', {
-        method: 'POST',
-        body: formData,
-      })
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        console.error('❌ Video upload failed:', errorData)
-        alert('Failed to upload video: ' + errorData.error)
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+      const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+      if (!supabaseUrl || !supabaseAnonKey) {
+        alert('Missing Supabase public env (NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY).')
         return
       }
 
-      const data = await response.json()
-      console.log('✅ Video uploaded successfully!')
-      console.log('🔗 Video URL:', data.url)
+      if (file.size > ADMIN_VIDEO_MAX_BYTES) {
+        alert(
+          `Video is too large (max ${Math.floor(ADMIN_VIDEO_MAX_BYTES / (1024 * 1024))} MB). Your file is ${(file.size / (1024 * 1024)).toFixed(1)} MB.`,
+        )
+        return
+      }
 
-      // Copy video markdown to clipboard for user to paste
-      const videoMarkdown = `!video[Video](${data.url})`
+      const isQuickTimeMov =
+        file.type === 'video/quicktime' || /\.mov$/i.test(file.name)
+      if (
+        isQuickTimeMov &&
+        !window.confirm(
+          'QuickTime (.mov) files often fail in the site video player (HEVC, ProRes, etc.). For reliable playback, export to MP4 with H.264 video and AAC audio first.\n\nUpload this .mov anyway?',
+        )
+      ) {
+        return
+      }
+
+      console.log('📹 Uploading video:', file.name, 'Size:', (file.size / 1024 / 1024).toFixed(2), 'MB')
+
+      const initRes = await fetch('/api/admin/upload-video/init', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          folder: 'selected-works-videos',
+          fileName: file.name,
+          contentType: file.type || 'video/mp4',
+          fileSize: file.size,
+        }),
+      })
+
+      if (!initRes.ok) {
+        const err = await initRes.json().catch(() => ({}))
+        console.error('❌ Video init failed:', err)
+        alert('Failed to start upload: ' + (err.error || initRes.statusText))
+        return
+      }
+
+      const { path, token, publicUrl } = (await initRes.json()) as {
+        path: string
+        token: string
+        publicUrl: string
+      }
+
+      const supabase = createClient(supabaseUrl, supabaseAnonKey)
+      const { error: uploadError } = await supabase.storage.from('media').uploadToSignedUrl(path, token, file, {
+        contentType: file.type || 'video/mp4',
+        cacheControl: '3600',
+        upsert: false,
+      })
+
+      if (uploadError) {
+        console.error('❌ Video upload failed:', uploadError)
+        let detail = uploadError.message
+        if (/exceeded the maximum allowed size/i.test(detail)) {
+          detail +=
+            '\n\nSupabase Storage enforces a max file size per project (Free plan: 50 MB). For ~108 MB videos, upgrade to Pro (or higher) and raise “Global file size limit” under Dashboard → Storage → Settings, then retry.'
+        }
+        alert('Failed to upload video: ' + detail)
+        return
+      }
+
+      console.log('✅ Video uploaded successfully!')
+      console.log('🔗 Video URL:', publicUrl)
+
+      const videoMarkdown = `!video[Video](${publicUrl})`
       
       try {
         await navigator.clipboard.writeText(videoMarkdown)

--- a/src/app/components/VideoPlayer.tsx
+++ b/src/app/components/VideoPlayer.tsx
@@ -52,8 +52,10 @@ export default function VideoPlayer({ src, className = '', poster }: VideoPlayer
           player.on('error', () => {
             const err = player.error()
             if (err) {
+              const url = srcRef.current
+              const looksLikeMov = /\.mov(\?|#|$)/i.test(url)
               let errorMessage = 'Unable to play this video.'
-              
+
               switch (err.code) {
                 case 1: // MEDIA_ERR_ABORTED
                   errorMessage = 'Video playback was aborted.'
@@ -62,10 +64,14 @@ export default function VideoPlayer({ src, className = '', poster }: VideoPlayer
                   errorMessage = 'A network error caused the video download to fail.'
                   break
                 case 3: // MEDIA_ERR_DECODE
-                  errorMessage = 'Video format is not supported by your browser. Try re-encoding to H.264 MP4.'
+                  errorMessage = looksLikeMov
+                    ? 'This .mov uses a codec your browser cannot decode (common with HEVC or ProRes). Re-export as MP4 with H.264 video and AAC audio.'
+                    : 'Video format is not supported by your browser. Try re-encoding to H.264 MP4.'
                   break
                 case 4: // MEDIA_ERR_SRC_NOT_SUPPORTED
-                  errorMessage = 'Video format is not supported or file is corrupted.'
+                  errorMessage = looksLikeMov
+                    ? 'QuickTime (.mov) files often use codecs that web players cannot play, even when the file is fine. Export to MP4: H.264 video + AAC audio for reliable playback.'
+                    : 'Video format is not supported or file is corrupted.'
                   break
                 default:
                   errorMessage = `Video error: ${err.message || 'Unknown error'}`

--- a/src/lib/admin-video-upload.ts
+++ b/src/lib/admin-video-upload.ts
@@ -1,0 +1,49 @@
+/** Allowed video MIME types for admin uploads (must match storage + player). */
+export const ADMIN_VIDEO_ALLOWED_MIME = [
+  'video/mp4',
+  'video/webm',
+  'video/ogg',
+  'video/quicktime',
+  'video/x-msvideo',
+  'video/x-matroska',
+  'video/mpeg',
+  'video/3gpp',
+  'video/x-flv',
+] as const
+
+/** Max size for direct browser → Supabase upload (bucket / plan limits may be lower). */
+export const ADMIN_VIDEO_MAX_BYTES = 500 * 1024 * 1024
+
+const EXT_BY_MIME: Record<string, string> = {
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/ogg': 'ogv',
+  'video/quicktime': 'mov',
+  'video/x-msvideo': 'avi',
+  'video/x-matroska': 'mkv',
+  'video/mpeg': 'mpeg',
+  'video/3gpp': '3gp',
+  'video/x-flv': 'flv',
+}
+
+const ALLOWED_FOLDERS = new Set(['selected-works-videos', 'field-notes-videos'])
+
+export function sanitizeVideoUploadFolder(raw: unknown): string {
+  if (typeof raw !== 'string' || !ALLOWED_FOLDERS.has(raw)) {
+    return 'selected-works-videos'
+  }
+  return raw
+}
+
+export function isAllowedVideoMime(contentType: string): boolean {
+  return (ADMIN_VIDEO_ALLOWED_MIME as readonly string[]).includes(contentType)
+}
+
+/** Prefer extension from MIME; fall back to sanitized client name. */
+export function safeVideoExtension(contentType: string, fileName: string): string | null {
+  const fromMime = EXT_BY_MIME[contentType]
+  if (fromMime) return fromMime
+  const ext = fileName.split('.').pop()?.toLowerCase()
+  if (ext && /^[a-z0-9]{2,5}$/.test(ext)) return ext
+  return null
+}


### PR DESCRIPTION
- Add signed-upload init API and shared admin video MIME/size helpers.
- Upload large videos from the editor via uploadToSignedUrl (bypasses API body limits).
- Cap legacy upload-video route at 8 MB with clear 413 response.
- Improve Supabase size-limit and .mov codec error messaging; confirm before .mov upload.