### PR TITLE
style: match grid outer padding to tile gap on works and notes

### DIFF
--- a/src/app/components/FieldNotesContent.tsx
+++ b/src/app/components/FieldNotesContent.tsx
@@ -66,7 +66,10 @@ const FieldNotesContent: React.FC = () => {
 
   return (
     <div className="c64-media">
-      <div className="grid grid-cols-4 sm:grid-cols-6" style={{ gap: 'var(--grid-major)' }}>
+      <div
+        className="grid grid-cols-4 sm:grid-cols-6"
+        style={{ gap: 'var(--grid-major)', padding: 'var(--grid-major)' }}
+      >
         {notes.map((note) => (
           <div
             key={note.id}

--- a/src/app/components/SelectedWorksContent.tsx
+++ b/src/app/components/SelectedWorksContent.tsx
@@ -70,7 +70,10 @@ const SelectedWorksContent: React.FC<SelectedWorksContentProps> = ({ initialWork
 
   return (
     <div className="c64-media">
-      <div className="grid grid-cols-4 sm:grid-cols-6" style={{ gap: 'var(--grid-major)' }}>
+      <div
+        className="grid grid-cols-4 sm:grid-cols-6"
+        style={{ gap: 'var(--grid-major)', padding: 'var(--grid-major)' }}
+      >
         {works.map((work) => (
           <div
             key={work.id}


### PR DESCRIPTION
Add var(--grid-major) padding around selected-works and field-notes grids so inset aligns with inter-cell gap when drawer content uses p-0.